### PR TITLE
Config option to set which color code prefix should be used.

### DIFF
--- a/src/ee/lutsu/alpha/mc/mytown/Formatter.java
+++ b/src/ee/lutsu/alpha/mc/mytown/Formatter.java
@@ -8,8 +8,13 @@ import ee.lutsu.alpha.mc.mytown.entities.Resident;
 
 public class Formatter {
     public static boolean formatChat = true;
-    private static final Pattern color_pattern = Pattern
+    public static String colorPrefix = "$";
+    private static Pattern colorPattern = Pattern
             .compile("(?i)\\$([0-9A-FK-OR])");
+    
+    public static void generateColorPattern() {
+        colorPattern = Pattern.compile("(?i)" + Pattern.quote(colorPrefix) + "([0-9A-FK-OR])");
+    }
 
     public static String formatLevel(Level lvl) {
         if (lvl == Level.SEVERE) {
@@ -110,12 +115,12 @@ public class Formatter {
         }
     }
 
-    public static String dollarToColorPrefix(String str) {
+    public static String applyColorCodes(String str) {
         if (str == null || str.equals("")) {
             return "";
         }
 
-        Matcher m = color_pattern.matcher(str);
+        Matcher m = colorPattern.matcher(str);
         String s = str;
 
         while (m.find()) {

--- a/src/ee/lutsu/alpha/mc/mytown/MyTown.java
+++ b/src/ee/lutsu/alpha/mc/mytown/MyTown.java
@@ -321,6 +321,12 @@ public class MyTown {
         prop.comment = "Setting this stops player messages from using the MyTown channel functionality.\n";
         prop.comment += "Explicit call of channel commands (/g, /h, etc.) still works unless disabled separatedly";
         PlayerEvents.disableAutoChatChannelUsage = prop.getBoolean(false);
+        
+        prop = config.get("Chat", "TextColoringPrefix", "$");
+        prop.comment = "This is the prefix used for color codes in chat. Default value $\n";
+        prop.comment += "When using with Bukkit plugins, it's recommended to change this to &";
+        Formatter.colorPrefix = prop.getString();
+        Formatter.generateColorPattern();
 
         prop = config.get("Chat", "FormatChat", true);
         prop.comment = "Should the chat be formatted";

--- a/src/ee/lutsu/alpha/mc/mytown/MyTown.java
+++ b/src/ee/lutsu/alpha/mc/mytown/MyTown.java
@@ -69,10 +69,8 @@ public class MyTown {
     public static String LIB_FOLDER = CONFIG_FOLDER + "lib/";
     public static String CONFIG_FILE = CONFIG_FOLDER + "MyTown.cfg";
 
-    public TownSettingCollection serverWildSettings = new TownSettingCollection(
-            true, true);
-    public TownSettingCollection serverSettings = new TownSettingCollection(
-            true, false);
+    public TownSettingCollection serverWildSettings = new TownSettingCollection(true, true);
+    public TownSettingCollection serverSettings = new TownSettingCollection(true, false);
     public Map<Integer, TownSettingCollection> worldWildSettings = new HashMap<Integer, TownSettingCollection>();
     public LinkedList<ItemIdRange> carts = null;
     public LinkedList<ItemIdRange> leftClickAccessBlocks = null;
@@ -124,8 +122,7 @@ public class MyTown {
         MinecraftForge.EVENT_BUS.register(events);
         GameRegistry.registerPlayerTracker(events);
         MinecraftForge.EVENT_BUS.register(ProtectionEvents.instance);
-        TickRegistry
-                .registerTickHandler(ProtectionEvents.instance, Side.SERVER);
+        TickRegistry.registerTickHandler(ProtectionEvents.instance, Side.SERVER);
         TickRegistry.registerTickHandler(TickHandler.instance, Side.SERVER);
         MinecraftForge.EVENT_BUS.register(WorldEvents.instance);
 
@@ -133,8 +130,7 @@ public class MyTown {
             loadCommandsConfig(config);
             WorldBorder.instance.continueGeneratingChunks();
         } catch (Exception var8) {
-            FMLLog.log(Level.SEVERE, var8, MOD_NAME
-                    + " was unable to load it\'s configuration successfully",
+            FMLLog.log(Level.SEVERE, var8, MOD_NAME + " was unable to load it\'s configuration successfully",
                     new Object[0]);
             throw new RuntimeException(var8);
         } finally {
@@ -145,8 +141,7 @@ public class MyTown {
     }
 
     @Mod.ServerStopping
-    public void serverStopping(FMLServerStoppingEvent ev)
-            throws InterruptedException {
+    public void serverStopping(FMLServerStoppingEvent ev) throws InterruptedException {
         WorldBorder.instance.stopGenerators();
     }
 
@@ -168,8 +163,7 @@ public class MyTown {
             TickHandler.instance.loadConfigs();
             WorldBorder.instance.loadConfig();
         } catch (Exception e) {
-            Log.severe(MOD_NAME
-                    + " was unable to load it\'s configuration successfully", e);
+            Log.severe(MOD_NAME + " was unable to load it\'s configuration successfully", e);
             throw new RuntimeException(e);
         } finally {
             config.save(); // re-save to add the missing configuration variables
@@ -195,8 +189,7 @@ public class MyTown {
         prop.comment = "Filename in config folder with the term translations";
 
         if (prop.getString() != null && !prop.getString().equals("")) {
-            TermTranslator.load(new File(CONFIG_FOLDER + prop.getString()),
-                    "custom", true);
+            TermTranslator.load(new File(CONFIG_FOLDER + prop.getString()), "custom", true);
         }
 
         prop = config.get("General", "NationAddsBlocks", 0);
@@ -227,43 +220,34 @@ public class MyTown {
         prop.comment = "Defines the cart id's which can be placed on a rail with carts perm on. Includes all cart-types.";
         carts = ItemIdRange.parseList(Arrays.asList(prop.getString().split(";")));
 
-        Town.pvpSafeTowns = config.get("General", "PVPSafeTown", "Spawn,Server", "Towns that PVP is disabled in, reguardless of the AllowPvpInTown setting.").getString().split(",");
+        Town.pvpSafeTowns = config
+                .get("General", "PVPSafeTown", "Spawn,Server",
+                        "Towns that PVP is disabled in, reguardless of the AllowPvpInTown setting.").getString()
+                .split(",");
 
-        prop = config
-                .get("General",
-                        "LeftClickAccessBlocks",
-                        "1000:2",
-                        "Which blocks should be considered as access when someone is hitting them. Like TE Barrels");
-        leftClickAccessBlocks = ItemIdRange.parseList(Arrays.asList(prop
-                .getString().split(";")));
+        prop = config.get("General", "LeftClickAccessBlocks", "1000:2",
+                "Which blocks should be considered as access when someone is hitting them. Like TE Barrels");
+        leftClickAccessBlocks = ItemIdRange.parseList(Arrays.asList(prop.getString().split(";")));
 
-        Resident.teleportToSpawnWaitSeconds = config.get("General",
-                "SpawnTeleportTimeout", Resident.teleportToSpawnWaitSeconds,
-                "How many seconds the /spawn teleport takes").getInt();
-        Resident.teleportToHomeWaitSeconds = config.get("General",
-                "HomeTeleportTimeout", Resident.teleportToHomeWaitSeconds,
-                "How many seconds the /home teleport takes").getInt();
+        Resident.teleportToSpawnWaitSeconds = config.get("General", "SpawnTeleportTimeout",
+                Resident.teleportToSpawnWaitSeconds, "How many seconds the /spawn teleport takes").getInt();
+        Resident.teleportToHomeWaitSeconds = config.get("General", "HomeTeleportTimeout",
+                Resident.teleportToHomeWaitSeconds, "How many seconds the /home teleport takes").getInt();
 
-        SavedHomeList.defaultIsBed = config
-                .get("General",
-                        "DefaultHomeIsBed",
-                        SavedHomeList.defaultIsBed,
-                        "Are the /sethome and /home commands with no home name linked to the bed location?")
-                .getBoolean(SavedHomeList.defaultIsBed);
+        SavedHomeList.defaultIsBed = config.get("General", "DefaultHomeIsBed", SavedHomeList.defaultIsBed,
+                "Are the /sethome and /home commands with no home name linked to the bed location?").getBoolean(
+                SavedHomeList.defaultIsBed);
     }
 
     private void loadCostConfigs(Configuration config) {
         config.addCustomCategoryComment("cost", "MyTown item based economy");
-        config.addCustomCategoryComment(
-                "cost.list",
+        config.addCustomCategoryComment("cost.list",
                 "Defines what and how much costs. Set the amount to 0 to disable the cost. Syntax: [amount]x[item id]:[sub id]");
         for (Cost c : Cost.values()) {
-            c.item = getItemStackConfig(config, "cost.list", c.name(), c.item,
-                    c.description);
+            c.item = getItemStackConfig(config, "cost.list", c.name(), c.item, c.description);
         }
 
-        if (!config.get("cost", "Enabled", true,
-                "Enable the so called economy module?").getBoolean(true)) {
+        if (!config.get("cost", "Enabled", true, "Enable the so called economy module?").getBoolean(true)) {
             Cost.disable();
         }
 
@@ -275,15 +259,11 @@ public class MyTown {
                 .getInt();
     }
 
-    private static ItemStack getItemStackConfig(Configuration config,
-            String cat, String node, ItemStack def, String comment) {
+    private static ItemStack getItemStackConfig(Configuration config, String cat, String node, ItemStack def,
+            String comment) {
         String sDef = "";
         if (def != null) {
-            sDef = def.stackSize
-                    + "x"
-                    + def.itemID
-                    + (def.getItemDamage() != 0 ? ":" + def.getItemDamage()
-                            : "");
+            sDef = def.stackSize + "x" + def.itemID + (def.getItemDamage() != 0 ? ":" + def.getItemDamage() : "");
         }
 
         String v = config.get(cat, node, sDef, comment).getString();
@@ -307,8 +287,7 @@ public class MyTown {
 
         prop = config.get("Database", "Type", "SQLite");
         prop.comment = "Database type to connect to";
-        MyTownDatasource.instance.currentType = Database.Type.matchType(prop
-                .getString());
+        MyTownDatasource.instance.currentType = Database.Type.matchType(prop.getString());
 
         prop = config.get("Database", "Prefix", "");
         prop.comment = "Table name prefix to use. <pre>_towns etc..";
@@ -338,6 +317,11 @@ public class MyTown {
     private void loadChatConfigs(Configuration config) {
         Property prop;
 
+        prop = config.get("Chat", "DisableAutomaticChannelUse", false);
+        prop.comment = "Setting this stops player messages from using the MyTown channel functionality.\n";
+        prop.comment += "Explicit call of channel commands (/g, /h, etc.) still works unless disabled separatedly";
+        PlayerEvents.disableAutoChatChannelUsage = prop.getBoolean(false);
+
         prop = config.get("Chat", "FormatChat", true);
         prop.comment = "Should the chat be formatted";
         Formatter.formatChat = prop.getBoolean(true);
@@ -350,13 +334,11 @@ public class MyTown {
         prop.comment = "Emote format to be used";
         Term.EmoteFormat.defaultVal = prop.getString();
 
-        prop = config.get("Chat", "PrivMsgInFormat",
-                Term.PrivMsgFormatIn.defaultVal);
+        prop = config.get("Chat", "PrivMsgInFormat", Term.PrivMsgFormatIn.defaultVal);
         prop.comment = "Private message format to be used when receiving. Vars starting with $s mean sender";
         Term.PrivMsgFormatIn.defaultVal = prop.getString();
 
-        prop = config.get("Chat", "PrivMsgOutFormat",
-                Term.PrivMsgFormatOut.defaultVal);
+        prop = config.get("Chat", "PrivMsgOutFormat", Term.PrivMsgFormatOut.defaultVal);
         prop.comment = "Private message format to be used when sending. Vars starting with $s mean sender";
         Term.PrivMsgFormatOut.defaultVal = prop.getString();
 
@@ -368,55 +350,46 @@ public class MyTown {
         prop.comment = "How many characters can one chat packet contain. It's global.";
         Packet3Chat.maxChatLength = prop.getInt(32767);
 
-        prop = config.get("Chat", "DefaultChannel",
-                ChatChannel.defaultChannel.name);
+        prop = config.get("Chat", "DefaultChannel", ChatChannel.defaultChannel.name);
         prop.comment = "Default chat channel for newcomers";
         ChatChannel.defaultChannel = ChatChannel.parse(prop.getString());
 
         for (ChatChannel ch : ChatChannel.values()) {
             prop = config.get("Chat", "Channel_" + ch.toString(), "");
             prop.comment = "<enabled>;<name>;<abbrevation>;<color>;<inlineswitch> like "
-                    + String.format("%s;%s;%s;%s", ch.enabled ? 1 : 0, ch.name,
-                            ch.abbrevation, ch.color);
+                    + String.format("%s;%s;%s;%s", ch.enabled ? 1 : 0, ch.name, ch.abbrevation, ch.color);
             ch.load(prop.getString());
         }
     }
 
     private void loadExtraProtectionConfig(Configuration config) {
-        ProtectionEvents.instance.enabled = config.get("ProtEx", "Enabled",
-                true, "Run the extra protections").getBoolean(true);
-        ProtectionEvents.instance.dynamicEnabling = config.get("ProtEx",
-                "DynamicEnabling", true,
+        ProtectionEvents.instance.enabled = config.get("ProtEx", "Enabled", true, "Run the extra protections")
+                .getBoolean(true);
+        ProtectionEvents.instance.dynamicEnabling = config.get("ProtEx", "DynamicEnabling", true,
                 "Load all modules for which mods are present").getBoolean(true);
 
         if (ProtectionEvents.instance.dynamicEnabling) {
             config.getCategory("ProtEx").clear();
 
-            config.get("ProtEx", "Enabled", true, "Run the extra protections?")
-                    .set(ProtectionEvents.instance.enabled);
-            config.get("ProtEx", "DynamicEnabling", true,
-                    "Load all modules for which mods are present").set(
+            config.get("ProtEx", "Enabled", true, "Run the extra protections?").set(ProtectionEvents.instance.enabled);
+            config.get("ProtEx", "DynamicEnabling", true, "Load all modules for which mods are present").set(
                     ProtectionEvents.instance.dynamicEnabling);
         } else {
             for (ProtBase prot : ProtectionEvents.getProtections()) {
-                prot.enabled = config.get("ProtEx", prot.getMod(),
-                        prot.defaultEnabled(), prot.getComment()).getBoolean(
-                        false);
+                prot.enabled = config.get("ProtEx", prot.getMod(), prot.defaultEnabled(), prot.getComment())
+                        .getBoolean(false);
             }
         }
     }
 
     private void loadCommandsConfig(Configuration config) {
         Property prop;
-        ServerCommandManager mgr = (ServerCommandManager) MinecraftServer
-                .getServer().getCommandManager();
+        ServerCommandManager mgr = (ServerCommandManager) MinecraftServer.getServer().getCommandManager();
 
         for (CommandBase cmd : commands) {
-            prop = config.get("Commands", "Enable_" + cmd.getCommandName(),
-                    true);
-            prop.comment = String.format(
-                    "Should the %s [/%s] command be used?", cmd.getClass()
-                            .getSimpleName(), cmd.getCommandName());
+            prop = config.get("Commands", "Enable_" + cmd.getCommandName(), true);
+            prop.comment = String.format("Should the %s [/%s] command be used?", cmd.getClass().getSimpleName(),
+                    cmd.getCommandName());
 
             if (prop.getBoolean(true)) {
                 mgr.registerCommand(cmd);
@@ -433,8 +406,7 @@ public class MyTown {
         serverSettings.saveHandler = new ISettingsSaveHandler() {
             @Override
             public void save(TownSettingCollection sender, Object tag) {
-                MyTown.instance.config.get("ServerPerms", "Server", "").set(
-                        sender.serialize());
+                MyTown.instance.config.get("ServerPerms", "Server", "").set(sender.serialize());
                 MyTown.instance.config.save();
             }
         };
@@ -445,8 +417,7 @@ public class MyTown {
         serverWildSettings.saveHandler = new ISettingsSaveHandler() {
             @Override
             public void save(TownSettingCollection sender, Object tag) {
-                MyTown.instance.config.get("WildPerms", "Server", "").set(
-                        sender.serialize());
+                MyTown.instance.config.get("WildPerms", "Server", "").set(sender.serialize());
                 MyTown.instance.config.save();
             }
         };
@@ -465,8 +436,7 @@ public class MyTown {
     }
 
     public TownSettingCollection getWorldWildSettings(int w) {
-        for (Entry<Integer, TownSettingCollection> set : worldWildSettings
-                .entrySet()) {
+        for (Entry<Integer, TownSettingCollection> set : worldWildSettings.entrySet()) {
             if (set.getKey() == w) {
                 return set.getValue();
             }
@@ -479,8 +449,7 @@ public class MyTown {
             @Override
             public void save(TownSettingCollection sender, Object tag) {
                 int w = (Integer) tag;
-                MyTown.instance.config.get("WildPerms",
-                        "Dim_" + String.valueOf(w), "").set(sender.serialize());
+                MyTown.instance.config.get("WildPerms", "Dim_" + String.valueOf(w), "").set(sender.serialize());
                 MyTown.instance.config.save();
             }
         };

--- a/src/ee/lutsu/alpha/mc/mytown/NoAccessException.java
+++ b/src/ee/lutsu/alpha/mc/mytown/NoAccessException.java
@@ -16,7 +16,7 @@ public class NoAccessException extends Exception {
 
     @Override
     public String toString() {
-        return Formatter.dollarToColorPrefix(Term.ErrCannotAccessCommand.toString());
+        return Formatter.applyColorCodes(Term.ErrCannotAccessCommand.toString());
     }
 
     private String getCustomizedMessage(String def) {

--- a/src/ee/lutsu/alpha/mc/mytown/commands/CmdChat.java
+++ b/src/ee/lutsu/alpha/mc/mytown/commands/CmdChat.java
@@ -198,7 +198,7 @@ public class CmdChat extends CommandBase {
         }
 
         if (ForgePerms.getPermissionsHandler().canAccess(sender.onlinePlayer.username, sender.onlinePlayer.worldObj.provider.getDimensionName(), "mytown.chat.allowcolors")) {
-            msg = Formatter.dollarToColorPrefix(msg);
+            msg = Formatter.applyColorCodes(msg);
         }
 
         String s;

--- a/src/ee/lutsu/alpha/mc/mytown/commands/CmdPrivateMsg.java
+++ b/src/ee/lutsu/alpha/mc/mytown/commands/CmdPrivateMsg.java
@@ -88,7 +88,7 @@ public class CmdPrivateMsg extends CommandServerMessage {
         if (ForgePerms.getPermissionsHandler().canAccess(sender.username,
                 sender.worldObj.provider.getDimensionName(),
                 "mytown.chat.allowcolors")) {
-            msg = Formatter.dollarToColorPrefix(msg);
+            msg = Formatter.applyColorCodes(msg);
         }
 
         for (ICommandSender cs : snoopers) {

--- a/src/ee/lutsu/alpha/mc/mytown/entities/Resident.java
+++ b/src/ee/lutsu/alpha/mc/mytown/entities/Resident.java
@@ -442,13 +442,23 @@ public class Resident {
     public String prefix() {
         String w = onlinePlayer != null ? String
                 .valueOf(onlinePlayer.dimension) : null;
-        return ForgePerms.getPermissionsHandler().getPrefix(name(), w);
+        
+        String prefix = ForgePerms.getPermissionsHandler().getPrefix(name(), w);
+        if (prefix != null) {
+          prefix = Formatter.applyColorCodes(prefix);
+        }
+        return prefix;
     }
 
     public String postfix() {
         String w = onlinePlayer != null ? String
-                .valueOf(onlinePlayer.dimension) : null;
-        return ForgePerms.getPermissionsHandler().getPostfix(name(), w);
+                .valueOf(onlinePlayer.dimension) : null;        
+        
+        String postfix = ForgePerms.getPermissionsHandler().getPostfix(name(), w);
+        if (postfix != null) {
+            postfix = Formatter.applyColorCodes(postfix);
+        }
+        return postfix;
     }
 
     public static Resident loadFromDB(int id, String name, Town town, Rank r,

--- a/src/ee/lutsu/alpha/mc/mytown/event/PlayerEvents.java
+++ b/src/ee/lutsu/alpha/mc/mytown/event/PlayerEvents.java
@@ -48,6 +48,9 @@ import ee.lutsu.alpha.mc.mytown.entities.TownSettingCollection.Permissions;
 import ee.lutsu.alpha.mc.mytown.event.tick.WorldBorder;
 
 public class PlayerEvents implements IPlayerTracker {
+
+    public static boolean disableAutoChatChannelUsage = false;
+
     @ForgeSubscribe(priority = EventPriority.HIGHEST)
     public void interact(PlayerInteractEvent ev) {
         if (ev.isCanceled()) {
@@ -55,8 +58,7 @@ public class PlayerEvents implements IPlayerTracker {
         }
 
         Resident r = source().getOrMakeResident(ev.entityPlayer);
-        if (ev.action == Action.RIGHT_CLICK_AIR
-                || ev.action == Action.RIGHT_CLICK_BLOCK) {
+        if (ev.action == Action.RIGHT_CLICK_AIR || ev.action == Action.RIGHT_CLICK_BLOCK) {
             if (r.pay.tryPayByHand()) {
                 ev.setCanceled(true);
                 r.onlinePlayer.stopUsingItem();
@@ -77,21 +79,15 @@ public class PlayerEvents implements IPlayerTracker {
 
         if (action == Action.RIGHT_CLICK_AIR) // entity or air click
         {
-            if (ev.entityPlayer.getHeldItem() != null
-                    && ev.entityPlayer.getHeldItem().getItem() != null) {
+            if (ev.entityPlayer.getHeldItem() != null && ev.entityPlayer.getHeldItem().getItem() != null) {
                 Item item = ev.entityPlayer.getHeldItem().getItem();
-                MovingObjectPosition pos = Utils
-                        .getMovingObjectPositionFromPlayer(
-                                r.onlinePlayer.worldObj, r.onlinePlayer, false);
+                MovingObjectPosition pos = Utils.getMovingObjectPositionFromPlayer(r.onlinePlayer.worldObj,
+                        r.onlinePlayer, false);
                 if (pos == null) {
-                    if (item instanceof ItemBow
-                            || item instanceof ItemEgg
-                            || item instanceof ItemPotion
-                            || item instanceof ItemFishingRod
-                            || item instanceof ItemExpBottle
+                    if (item instanceof ItemBow || item instanceof ItemEgg || item instanceof ItemPotion
+                            || item instanceof ItemFishingRod || item instanceof ItemExpBottle
                             || item instanceof ItemEnderEye
-                            || item.getClass().getSimpleName()
-                                    .equalsIgnoreCase("ItemNanoBow")) {
+                            || item.getClass().getSimpleName().equalsIgnoreCase("ItemNanoBow")) {
                         perm = Permissions.Build;
                     } else {
                         return;
@@ -117,32 +113,25 @@ public class PlayerEvents implements IPlayerTracker {
             }
         }
 
-        TownBlock targetBlock = MyTownDatasource.instance.getPermBlockAtCoord(
-                ev.entityPlayer.dimension, x, y, z);
+        TownBlock targetBlock = MyTownDatasource.instance.getPermBlockAtCoord(ev.entityPlayer.dimension, x, y, z);
 
         if (action == Action.RIGHT_CLICK_BLOCK
                 && ev.entityPlayer.getHeldItem() != null
                 && ev.entityPlayer.getHeldItem().getItem() != null
-                && (ev.entityPlayer.getHeldItem().getItem() instanceof ItemMinecart || ItemIdRange
-                        .contains(MyTown.instance.carts, ev.entityPlayer
-                                .getHeldItem()))) {
+                && (ev.entityPlayer.getHeldItem().getItem() instanceof ItemMinecart || ItemIdRange.contains(
+                        MyTown.instance.carts, ev.entityPlayer.getHeldItem()))) {
             int en = ev.entityPlayer.worldObj.getBlockId(x, y, z);
             if (Block.blocksList[en] instanceof BlockRail) {
-                if (targetBlock != null
-                        && targetBlock.town() != null
-                        && targetBlock.settings.allowCartInteraction
+                if (targetBlock != null && targetBlock.town() != null && targetBlock.settings.allowCartInteraction
                         || (targetBlock == null || targetBlock.town() == null)
-                        && MyTown.instance
-                                .getWorldWildSettings(ev.entityPlayer.dimension).allowCartInteraction) {
+                        && MyTown.instance.getWorldWildSettings(ev.entityPlayer.dimension).allowCartInteraction) {
                     return;
                 }
             }
         } else if (action == Action.RIGHT_CLICK_BLOCK) {
             if (!r.onlinePlayer.isSneaking()) {
-                TileEntity te = r.onlinePlayer.worldObj.getBlockTileEntity(x,
-                        y, z);
-                if (te != null && te instanceof IInventory
-                        && ((IInventory) te).isUseableByPlayer(r.onlinePlayer)) {
+                TileEntity te = r.onlinePlayer.worldObj.getBlockTileEntity(x, y, z);
+                if (te != null && te instanceof IInventory && ((IInventory) te).isUseableByPlayer(r.onlinePlayer)) {
                     perm = Permissions.Access;
                 }
             }
@@ -166,8 +155,7 @@ public class PlayerEvents implements IPlayerTracker {
              */
 
             // placing a block
-            if (ev.face != -1 && perm == Permissions.Build && item != null
-                    && item instanceof ItemBlock) {
+            if (ev.face != -1 && perm == Permissions.Build && item != null && item instanceof ItemBlock) {
                 if (ev.face == 0) {
                     y--;
                 } else if (ev.face == 1) {
@@ -182,8 +170,7 @@ public class PlayerEvents implements IPlayerTracker {
                     x++;
                 }
 
-                targetBlock = MyTownDatasource.instance.getPermBlockAtCoord(
-                        ev.entityPlayer.dimension, x, y, z);
+                targetBlock = MyTownDatasource.instance.getPermBlockAtCoord(ev.entityPlayer.dimension, x, y, z);
             }
         }
 
@@ -194,8 +181,8 @@ public class PlayerEvents implements IPlayerTracker {
                 World w = ev.entityPlayer.worldObj;
                 // Log.info("Block is %s:%s", w.getBlockId(x, y, z),
                 // w.getBlockMetadata(x, y, z));
-                if (ItemIdRange.contains(MyTown.instance.leftClickAccessBlocks,
-                        w.getBlockId(x, y, z), w.getBlockMetadata(x, y, z))) {
+                if (ItemIdRange.contains(MyTown.instance.leftClickAccessBlocks, w.getBlockId(x, y, z),
+                        w.getBlockMetadata(x, y, z))) {
                     perm = Permissions.Access;
                     if (r.canInteract(targetBlock, perm)) {
                         return;
@@ -206,11 +193,9 @@ public class PlayerEvents implements IPlayerTracker {
             r.onlinePlayer.stopUsingItem();
             ev.setCanceled(true);
             if (perm == Permissions.Access) {
-                ev.entityPlayer.sendChatToPlayer(Term.ErrPermCannotAccessHere
-                        .toString());
+                ev.entityPlayer.sendChatToPlayer(Term.ErrPermCannotAccessHere.toString());
             } else {
-                ev.entityPlayer.sendChatToPlayer(Term.ErrPermCannotBuildHere
-                        .toString());
+                ev.entityPlayer.sendChatToPlayer(Term.ErrPermCannotBuildHere.toString());
             }
         }
     }
@@ -226,8 +211,7 @@ public class PlayerEvents implements IPlayerTracker {
         if (!r.canInteract(ev.item)) {
             long time = System.currentTimeMillis();
             if (time > r.pickupWarningCooldown) {
-                ev.entityPlayer.sendChatToPlayer(Term.ErrPermCannotPickup
-                        .toString());
+                ev.entityPlayer.sendChatToPlayer(Term.ErrPermCannotPickup.toString());
                 r.pickupWarningCooldown = time + Resident.pickupSpamCooldown;
             }
             ev.setCanceled(true);
@@ -243,8 +227,7 @@ public class PlayerEvents implements IPlayerTracker {
         Resident attacker = source().getOrMakeResident(ev.entityPlayer);
 
         if (!attacker.canAttack(ev.target)) {
-            ev.entityPlayer.sendChatToPlayer(Term.ErrPermCannotAttack
-                    .toString());
+            ev.entityPlayer.sendChatToPlayer(Term.ErrPermCannotAttack.toString());
             ev.setCanceled(true);
         }
     }
@@ -256,13 +239,10 @@ public class PlayerEvents implements IPlayerTracker {
         }
 
         if (ev.entityLiving instanceof EntityPlayer) {
-            Resident t = source().getOrMakeResident(
-                    (EntityPlayer) ev.entityLiving);
+            Resident t = source().getOrMakeResident((EntityPlayer) ev.entityLiving);
 
-            if (ev.source.getEntity() != null
-                    && !t.canBeAttackedBy(ev.source.getEntity())
-                    || ev.source.getSourceOfDamage() != null
-                    && !t.canBeAttackedBy(ev.source.getSourceOfDamage())) {
+            if (ev.source.getEntity() != null && !t.canBeAttackedBy(ev.source.getEntity())
+                    || ev.source.getSourceOfDamage() != null && !t.canBeAttackedBy(ev.source.getSourceOfDamage())) {
                 ev.setCanceled(true);
                 // spamming
                 /*
@@ -277,16 +257,12 @@ public class PlayerEvents implements IPlayerTracker {
         Entity target = ev.entity;
         Resident attacker = null;
 
-        if (ev.source.getEntity() != null
-                && ev.source.getEntity() instanceof EntityPlayer) {
-            attacker = source().getOrMakeResident(
-                    (EntityPlayer) ev.source.getEntity());
+        if (ev.source.getEntity() != null && ev.source.getEntity() instanceof EntityPlayer) {
+            attacker = source().getOrMakeResident((EntityPlayer) ev.source.getEntity());
         }
 
-        if (ev.source.getSourceOfDamage() != null
-                && ev.source.getSourceOfDamage() instanceof EntityPlayer) {
-            attacker = source().getOrMakeResident(
-                    (EntityPlayer) ev.source.getSourceOfDamage());
+        if (ev.source.getSourceOfDamage() != null && ev.source.getSourceOfDamage() instanceof EntityPlayer) {
+            attacker = source().getOrMakeResident((EntityPlayer) ev.source.getSourceOfDamage());
         }
 
         if (!attacker.isOnline()) {
@@ -295,8 +271,7 @@ public class PlayerEvents implements IPlayerTracker {
         }
 
         if (!attacker.canAttack(target)) {
-            attacker.onlinePlayer.sendChatToPlayer(Term.ErrPermCannotAttack
-                    .toString());
+            attacker.onlinePlayer.sendChatToPlayer(Term.ErrPermCannotAttack.toString());
             ev.setCanceled(true);
             return;
         }
@@ -311,8 +286,7 @@ public class PlayerEvents implements IPlayerTracker {
         Resident r = source().getOrMakeResident(ev.entityPlayer);
 
         if (!r.canInteract(ev.target)) {
-            ev.entityPlayer.sendChatToPlayer(Term.ErrPermCannotInteract
-                    .toString());
+            ev.entityPlayer.sendChatToPlayer(Term.ErrPermCannotInteract.toString());
             ev.setCanceled(true);
         }
     }
@@ -325,20 +299,16 @@ public class PlayerEvents implements IPlayerTracker {
 
         Resident r = source().getOrMakeResident((EntityPlayer) ev.collider);
 
-        TownBlock t = source().getBlock(r.onlinePlayer.dimension,
-                ev.minecart.chunkCoordX, ev.minecart.chunkCoordZ);
+        TownBlock t = source().getBlock(r.onlinePlayer.dimension, ev.minecart.chunkCoordX, ev.minecart.chunkCoordZ);
 
-        if (t == null || t.town() == null || t.town() == r.town()
-                || t.settings.allowCartInteraction) {
+        if (t == null || t.town() == null || t.town() == r.town() || t.settings.allowCartInteraction) {
             return;
         }
 
         long time = System.currentTimeMillis();
         if (t.town().minecraftNotificationTime < time) {
-            t.town().minecraftNotificationTime = time
-                    + Town.dontSendCartNotification;
-            t.town().sendNotification(Level.WARNING,
-                    Term.MinecartMessedWith.toString());
+            t.town().minecraftNotificationTime = time + Town.dontSendCartNotification;
+            t.town().sendNotification(Level.WARNING, Term.MinecartMessedWith.toString());
         }
     }
 
@@ -352,24 +322,20 @@ public class PlayerEvents implements IPlayerTracker {
         Resident r = source().getOrMakeResident(player);
 
         if (!WorldBorder.instance.isWithinArea(player)) {
-            Log.warning(String
-                    .format("Player %s logged in over the world edge %s (%s, %s, %s). Sending to spawn.",
-                            r.name(), player.dimension, player.posX,
-                            player.posY, player.posZ));
+            Log.warning(String.format("Player %s logged in over the world edge %s (%s, %s, %s). Sending to spawn.",
+                    r.name(), player.dimension, player.posX, player.posY, player.posZ));
             r.respawnPlayer();
         }
 
-        TownBlock t = source().getBlock(r.onlinePlayer.dimension,
-                player.chunkCoordX, player.chunkCoordZ);
+        TownBlock t = source().getBlock(r.onlinePlayer.dimension, player.chunkCoordX, player.chunkCoordZ);
 
         r.location = t != null && t.town() != null ? t.town() : null;
         r.location2 = t != null && t.town() != null ? t.owner() : null;
 
         if (!r.canInteract(t, (int) player.posY, Permissions.Enter)) {
-            Log.warning(String
-                    .format("Player %s logged in at a enemy town %s (%s, %s, %s, %s) with bouncing on. Sending to spawn.",
-                            r.name(), r.location.name(), player.dimension,
-                            player.posX, player.posY, player.posZ));
+            Log.warning(String.format(
+                    "Player %s logged in at a enemy town %s (%s, %s, %s, %s) with bouncing on. Sending to spawn.",
+                    r.name(), r.location.name(), player.dimension, player.posX, player.posY, player.posZ));
             r.respawnPlayer();
         }
 
@@ -392,20 +358,23 @@ public class PlayerEvents implements IPlayerTracker {
     }
 
     @Override
-    public void onPlayerChangedDimension(EntityPlayer player) {}
+    public void onPlayerChangedDimension(EntityPlayer player) {
+    }
 
     @Override
-    public void onPlayerRespawn(EntityPlayer player) {}
+    public void onPlayerRespawn(EntityPlayer player) {
+    }
 
     @ForgeSubscribe
     public void serverChat(ServerChatEvent ev) {
         if (ev.isCanceled() || ev.message == null || ev.message.trim().length() < 1 || !Formatter.formatChat) {
             return;
         }
-
-        ev.setCanceled(true);
-        Resident res = source().getOrMakeResident(ev.player);
-        CmdChat.sendToChannelFromDirectTalk(res, ev.message, res.activeChannel, false);
+        if (!disableAutoChatChannelUsage) {
+            ev.setCanceled(true);
+            Resident res = source().getOrMakeResident(ev.player);
+            CmdChat.sendToChannelFromDirectTalk(res, ev.message, res.activeChannel, false);
+        }
     }
 
     @ForgeSubscribe
@@ -416,8 +385,7 @@ public class PlayerEvents implements IPlayerTracker {
 
         // so we don't re-link to player to be online
         // as this is called after the player logs off
-        Resident res = source().getOrMakeResident(
-                (EntityPlayer) ev.entityLiving);
+        Resident res = source().getOrMakeResident((EntityPlayer) ev.entityLiving);
 
         if (res != null && res.isOnline()) {
             res.update();


### PR DESCRIPTION
1st commit is in case someone wishes to use a different chat system, like herochat (if you use chat listeners both on bukkit and forge side, message duplication may occur. I had that happen when glacy staff chat was used together with mytown)

2nd commit is for changing the color code prefix, from the default "$" alpha made, to anything the user desires (usually "&" to work with bukkit though)
