### PR TITLE
Changes in mytown 1.5.2

### DIFF
--- a/src/ee/lutsu/alpha/mc/mytown/MyTown.java
+++ b/src/ee/lutsu/alpha/mc/mytown/MyTown.java
@@ -204,6 +204,10 @@ public class MyTown {
         prop = config.get("General", "MinDistanceFromAnotherTown", 50);
         prop.comment = "How many blocks(chunks) apart have the town blocks be";
         Town.minDistanceFromOtherTown = prop.getInt(5);
+        
+        prop = config.get("General", "AllowFarawayClaims", true);
+        prop.comment = "Whether players are allowed to claim chunks not connected to earlier ones";
+        Town.allowFarawayClaims = prop.getBoolean(true);
 
         prop = config.get("General", "AllowTownMemberPvp", false);
         prop.comment = "First check. Can one town member hit a member of the same town? Anywhere. Also called friendlyfire";

--- a/src/ee/lutsu/alpha/mc/mytown/MyTownDatasource.java
+++ b/src/ee/lutsu/alpha/mc/mytown/MyTownDatasource.java
@@ -18,9 +18,9 @@ public class MyTownDatasource extends MyTownDB {
 	public static MyTownDatasource instance = new MyTownDatasource();
 
 	public HashMap<String, Resident> residents = new HashMap<String, Resident>();
-	public HashSet<Town> towns = new HashSet<Town>();
+	public HashMap<String, Town> towns = new HashMap<String, Town>();
 	public HashMap<String, TownBlock> blocks = new HashMap<String, TownBlock>();
-	public HashSet<Nation> nations = new HashSet<Nation>();
+	public HashMap<String, Nation> nations = new HashMap<String, Nation>();
 	
 	public String getTownBlockKey(int dim, int x, int z) {
 		return dim + ";" + x + ";" + z;
@@ -33,18 +33,18 @@ public class MyTownDatasource extends MyTownDB {
 
 	public void init() throws Exception {
 		residents = new HashMap<String, Resident>();
-		towns = new HashSet<Town>();
+		towns = new HashMap<String, Town>();
 		blocks = new HashMap<String, TownBlock>();
-		nations = new HashSet<Nation>();
+		nations = new HashMap<String, Nation>();
 
 		dispose();
 		connect();
 		load();
 
-		towns.addAll(loadTowns());
+		towns.putAll(loadTowns());
 		residents.putAll(loadResidents()); // links to towns
 
-		for (Town t : towns) {
+		for (Town t : towns.values()) {
 			for (TownBlock res : t.blocks()) {
 				if (res.owner_name != null) // map block owners
 				{
@@ -57,7 +57,7 @@ public class MyTownDatasource extends MyTownDB {
 			}
 		}
 
-		nations.addAll(loadNations());
+		nations.putAll(loadNations());
 
 		addAllOnlinePlayers();
 	}
@@ -70,33 +70,25 @@ public class MyTownDatasource extends MyTownDB {
 	}
 
 	public void addTown(Town t) {
-		towns.add(t);
+		towns.put(t.name().toLowerCase(), t);
 	}
 
 	public void addNation(Nation n) {
-		nations.add(n);
+		nations.put(n.name().toLowerCase(), n);
 	}
 
 	public TownBlock getOrMakeBlock(int world_dimension, int x, int z) {
-		long start = System.nanoTime();
+
 		TownBlock res = blocks.get(getTownBlockKey(world_dimension, x, z));
 		if (res == null) {
 			res = new TownBlock(world_dimension, x, z);
 			blocks.put(getTownBlockKey(world_dimension, x, z), res);
 		}
-
-		long stop = System.nanoTime();
-		Log.info("getOrMakeBlock took: %d", stop - start);
 		return res;
 	}
 
 	public TownBlock getBlock(int world_dimension, int x, int z) {
-		long start = System.nanoTime();
-		TownBlock res = blocks.get(getTownBlockKey(world_dimension, x, z));
-
-		long stop = System.nanoTime();
-		Log.info("getBlock took: %d", stop - start);
-		return res;
+	    return blocks.get(getTownBlockKey(world_dimension, x, z));
 	}
 
 	public TownBlock getPermBlockAtCoord(int world_dimension, int x, int y, int z) {
@@ -115,82 +107,45 @@ public class MyTownDatasource extends MyTownDB {
 	}
 
 	public Town getTown(String name) {
-		long start = System.nanoTime();
-		for (Town res : towns) {
-			if (res.name().equalsIgnoreCase(name)) {
-				long stop = System.nanoTime();
-				Log.info("getTown took: %d", stop - start);
-				return res;
-			}
-		}
-		
-		long stop = System.nanoTime();
-		Log.info("getTown took: %d", stop - start);
-
-		return null;
+	    return towns.get(name.toLowerCase());
 	}
 
 	@Override
 	public Town getTown(int id) {
-		long start = System.nanoTime();
-		for (Town res : towns) {
-			if (res.id() == id) {
-				long stop = System.nanoTime();
-				Log.info("getTown took: %d", stop - start);
+		for (Town res : towns.values()) {
+			if (res.id() == id) {	
 				return res;
 			}
 		}
-		long stop = System.nanoTime();
-		Log.info("getTown took: %d", stop - start);
-
 		return null;
 	}
 
 	public Nation getNation(String name) {
-		for (Nation res : nations) {
-			if (res.name().equalsIgnoreCase(name)) {
-				return res;
-			}
-		}
-
-		return null;
+	    return nations.get(name.toLowerCase());
 	}
 
 	public synchronized Resident getOrMakeResident(EntityPlayer player) {
-		long start = System.nanoTime();
 		Resident res = residents.get(player.getEntityName().toLowerCase());
 
 		if (res == null) {
 			res = makeResident(player.getEntityName());
 		}
 		res.onlinePlayer = player;
-		long stop = System.nanoTime();
-		Log.info("getOrMakeResident took: %d", stop - start);
 		return res;
 	}
 
-	public Resident getResident(EntityPlayer player) {
-		long start = System.nanoTime();
-		
-		Resident res = residents.get(player.getEntityName().toLowerCase());
-		
-		long stop = System.nanoTime();
-		Log.info("getResident took: %d", stop - start);
-
-		return res;
+	public Resident getResident(EntityPlayer player) {	
+	    return residents.get(player.getEntityName().toLowerCase());
 	}
 
 	public Resident getOrMakeResident(String name) // case in-sensitive
 	{
-		long start = System.nanoTime();
 		Resident res = residents.get(name.toLowerCase());
 
 		if (res == null) {
 			res = makeResident(name);
 		}
 		
-		long stop = System.nanoTime();
-		Log.info("getOrMakeResident took: %d", stop - start);
 		return res;
 	}
 	

--- a/src/ee/lutsu/alpha/mc/mytown/MyTownDatasource.java
+++ b/src/ee/lutsu/alpha/mc/mytown/MyTownDatasource.java
@@ -14,275 +14,305 @@ import ee.lutsu.alpha.mc.mytown.entities.TownBlock;
 import ee.lutsu.alpha.mc.mytown.sql.MyTownDB;
 
 public class MyTownDatasource extends MyTownDB {
-    public static MyTownDatasource instance = new MyTownDatasource();
+	public static MyTownDatasource instance = new MyTownDatasource();
 
-    public HashSet<Resident> residents = new HashSet<Resident>();
-    public HashSet<Town> towns = new HashSet<Town>();
-    public HashSet<TownBlock> blocks = new HashSet<TownBlock>();
-    public HashSet<Nation> nations = new HashSet<Nation>();
+	public HashSet<Resident> residents = new HashSet<Resident>();
+	public HashSet<Town> towns = new HashSet<Town>();
+	public HashSet<TownBlock> blocks = new HashSet<TownBlock>();
+	public HashSet<Nation> nations = new HashSet<Nation>();
 
-    public void init() throws Exception {
-        residents = new HashSet<Resident>();
-        towns = new HashSet<Town>();
-        blocks = new HashSet<TownBlock>();
-        nations = new HashSet<Nation>();
+	public void init() throws Exception {
+		residents = new HashSet<Resident>();
+		towns = new HashSet<Town>();
+		blocks = new HashSet<TownBlock>();
+		nations = new HashSet<Nation>();
 
-        dispose();
-        connect();
-        load();
+		dispose();
+		connect();
+		load();
 
-        towns.addAll(loadTowns());
-        residents.addAll(loadResidents()); // links to towns
+		towns.addAll(loadTowns());
+		residents.addAll(loadResidents()); // links to towns
 
-        for (Town t : towns) {
-            for (TownBlock res : t.blocks()) {
-                if (res.owner_name != null) // map block owners
-                {
-                    Resident r = getResident(res.owner_name);
-                    res.sqlSetOwner(r);
-                    res.owner_name = null;
-                }
+		for (Town t : towns) {
+			for (TownBlock res : t.blocks()) {
+				if (res.owner_name != null) // map block owners
+				{
+					Resident r = getResident(res.owner_name);
+					res.sqlSetOwner(r);
+					res.owner_name = null;
+				}
 
-                blocks.add(res); // add block to global list
-            }
-        }
+				blocks.add(res); // add block to global list
+			}
+		}
 
-        nations.addAll(loadNations());
+		nations.addAll(loadNations());
 
-        addAllOnlinePlayers();
-    }
+		addAllOnlinePlayers();
+	}
 
-    public void addAllOnlinePlayers() {
-        for (Object obj : MinecraftServer.getServer().getConfigurationManager().playerEntityList) {
-            EntityPlayer pl = (EntityPlayer) obj;
-            getOrMakeResident(pl);
-        }
-    }
+	public void addAllOnlinePlayers() {
+		for (Object obj : MinecraftServer.getServer().getConfigurationManager().playerEntityList) {
+			EntityPlayer pl = (EntityPlayer) obj;
+			getOrMakeResident(pl);
+		}
+	}
 
-    public void addTown(Town t) {
-        towns.add(t);
-    }
+	public void addTown(Town t) {
+		towns.add(t);
+	}
 
-    public void addNation(Nation n) {
-        nations.add(n);
-    }
+	public void addNation(Nation n) {
+		nations.add(n);
+	}
 
-    public TownBlock getOrMakeBlock(int world_dimension, int x, int z) {
-        for (TownBlock res : blocks) {
-            if (res.equals(world_dimension, x, z)) {
-                return res;
-            }
-        }
+	public TownBlock getOrMakeBlock(int world_dimension, int x, int z) {
+		long start = System.nanoTime();
+		for (TownBlock res : blocks) {
+			if (res.equals(world_dimension, x, z)) {
+				long stop = System.nanoTime();
+				Log.info("getOrMakeBlock took: %l", stop - start);
+				return res;
+			}
+		}
 
-        TownBlock res = new TownBlock(world_dimension, x, z);
-        blocks.add(res);
-        return res;
-    }
+		TownBlock res = new TownBlock(world_dimension, x, z);
+		blocks.add(res);
+		long stop = System.nanoTime();
+		Log.info("getOrMakeBlock took: %l", stop - start);
+		return res;
+	}
 
-    public TownBlock getBlock(int world_dimension, int x, int z) {
-        for (TownBlock res : blocks) {
-            if (res.equals(world_dimension, x, z)) {
-                return res;
-            }
-        }
+	public TownBlock getBlock(int world_dimension, int x, int z) {
+		long start = System.nanoTime();
+		for (TownBlock res : blocks) {
+			if (res.equals(world_dimension, x, z)) {
+				long stop = System.nanoTime();
+				Log.info("getBlock took: %l", stop - start);
+				return res;
+			}
+		}
+		long stop = System.nanoTime();
+		Log.info("getBlock took: %l", stop - start);
+		return null;
+	}
 
-        return null;
-    }
+	public TownBlock getPermBlockAtCoord(int world_dimension, int x, int y, int z) {
+		return getPermBlockAtCoord(world_dimension, x, y, y, z);
+	}
 
-    public TownBlock getPermBlockAtCoord(int world_dimension, int x, int y, int z) {
-        return getPermBlockAtCoord(world_dimension, x, y, y, z);
-    }
+	public TownBlock getPermBlockAtCoord(int world_dimension, int x, int yFrom, int yTo, int z) {
+		TownBlock targetBlock = getBlock(world_dimension, ChunkCoord.getCoord(x), ChunkCoord.getCoord(z));
+		if (targetBlock != null && targetBlock.settings.yCheckOn) {
+			if (yTo < targetBlock.settings.yCheckFrom || yFrom > targetBlock.settings.yCheckTo) {
+				targetBlock = targetBlock.getFirstFullSidingClockwise(targetBlock.town());
+			}
+		}
 
-    public TownBlock getPermBlockAtCoord(int world_dimension, int x, int yFrom,
-            int yTo, int z) {
-        TownBlock targetBlock = getBlock(world_dimension, ChunkCoord
-                .getCoord(x), ChunkCoord.getCoord(z));
-        if (targetBlock != null && targetBlock.settings.yCheckOn) {
-            if (yTo < targetBlock.settings.yCheckFrom
-                    || yFrom > targetBlock.settings.yCheckTo) {
-                targetBlock = targetBlock
-                        .getFirstFullSidingClockwise(targetBlock.town());
-            }
-        }
+		return targetBlock;
+	}
 
-        return targetBlock;
-    }
+	public Town getTown(String name) {
+		long start = System.nanoTime();
+		for (Town res : towns) {
+			if (res.name().equalsIgnoreCase(name)) {
+				long stop = System.nanoTime();
+				Log.info("getTown took: %l", stop - start);
+				return res;
+			}
+		}
+		
+		long stop = System.nanoTime();
+		Log.info("getTown took: %l", stop - start);
 
-    public Town getTown(String name) {
-        for (Town res : towns) {
-            if (res.name().equalsIgnoreCase(name)) {
-                return res;
-            }
-        }
+		return null;
+	}
 
-        return null;
-    }
+	@Override
+	public Town getTown(int id) {
+		long start = System.nanoTime();
+		for (Town res : towns) {
+			if (res.id() == id) {
+				long stop = System.nanoTime();
+				Log.info("getTown took: %l", stop - start);
+				return res;
+			}
+		}
+		long stop = System.nanoTime();
+		Log.info("getTown took: %l", stop - start);
 
-    @Override
-    public Town getTown(int id) {
-        for (Town res : towns) {
-            if (res.id() == id) {
-                return res;
-            }
-        }
+		return null;
+	}
 
-        return null;
-    }
+	public Nation getNation(String name) {
+		for (Nation res : nations) {
+			if (res.name().equalsIgnoreCase(name)) {
+				return res;
+			}
+		}
 
-    public Nation getNation(String name) {
-        for (Nation res : nations) {
-            if (res.name().equalsIgnoreCase(name)) {
-                return res;
-            }
-        }
+		return null;
+	}
 
-        return null;
-    }
+	public synchronized Resident getOrMakeResident(EntityPlayer player) {
+		long start = System.nanoTime();
+		for (Resident res : residents) {
+			if (res.onlinePlayer == player) {
+				long stop = System.nanoTime();
+				Log.info("getOrMakeResident took: %l", stop - start);
+				return res;
+			}
+		}
 
-    public synchronized Resident getOrMakeResident(EntityPlayer player) {
-        for (Resident res : residents) {
-            if (res.onlinePlayer == player) {
-                return res;
-            }
-        }
+		Resident r = getOrMakeResident(player.getEntityName());
+		r.onlinePlayer = player;
+		long stop = System.nanoTime();
+		Log.info("getOrMakeResident took: %l", stop - start);
+		return r;
+	}
 
-        Resident r = getOrMakeResident(player.getEntityName());
-        r.onlinePlayer = player;
-        return r;
-    }
+	public Resident getResident(EntityPlayer player) {
+		long start = System.nanoTime();
+		for (Resident res : residents) {
+			if (res.onlinePlayer == player) {
+				long stop = System.nanoTime();
+				Log.info("getResident took: %l", stop - start);
+				return res;
+			}
+		}
+		long stop = System.nanoTime();
+		Log.info("getResident took: %l", stop - start);
 
-    public Resident getResident(EntityPlayer player) {
-        for (Resident res : residents) {
-            if (res.onlinePlayer == player) {
-                return res;
-            }
-        }
+		return null;
+	}
 
-        return null;
-    }
+	public Resident getOrMakeResident(String name) // case sensitive
+	{
+		long start = System.nanoTime();
+		for (Resident res : residents) {
+			if (res.name().equals(name)) {
+				long stop = System.nanoTime();
+				Log.info("getOrMakeResident took: %l", stop - start);
+				return res;
+			}
+		}
 
-    public Resident getOrMakeResident(String name) // case sensitive
-    {
-        for (Resident res : residents) {
-            if (res.name().equals(name)) {
-                return res;
-            }
-        }
+		Resident res = new Resident(name);
+		residents.add(res);
+		long stop = System.nanoTime();
+		Log.info("getOrMakeResident took: %l", stop - start);
+		return res;
+	}
 
-        Resident res = new Resident(name);
-        residents.add(res);
-        return res;
-    }
+	public Resident getResident(String name) // case in-sensitive
+	{
+		long start = System.nanoTime();
+		for (Resident res : residents) {
+			if (res.name().equalsIgnoreCase(name)) {
+				long stop = System.nanoTime();
+				Log.info("getResident took: %l", stop - start);
+				return res;
+			}
+		}
+		long stop = System.nanoTime();
+		Log.info("getResident took: %l", stop - start);
 
-    public Resident getResident(String name) // case in-sensitive
-    {
-        for (Resident res : residents) {
-            if (res.name().equalsIgnoreCase(name)) {
-                return res;
-            }
-        }
+		return null;
+	}
 
-        return null;
-    }
+	public List<Resident> getOnlineResidents() {
+		ArrayList<Resident> ret = new ArrayList<Resident>();
+		for (Resident res : residents) {
+			if (res.isOnline()) {
+				ret.add(res);
+			}
+		}
 
-    public List<Resident> getOnlineResidents() {
-        ArrayList<Resident> ret = new ArrayList<Resident>();
-        for (Resident res : residents) {
-            if (res.isOnline()) {
-                ret.add(res);
-            }
-        }
+		return ret;
+	}
 
-        return ret;
-    }
+	public void unloadTown(Town t) {
+		towns.remove(t);
+	}
 
-    public void unloadTown(Town t) {
-        towns.remove(t);
-    }
+	public void unloadNation(Nation n) {
+		nations.remove(n);
+	}
 
-    public void unloadNation(Nation n) {
-        nations.remove(n);
-    }
+	public void unloadBlock(TownBlock b) {
+		b.settings.setParent(null);
+		blocks.remove(b);
+	}
 
-    public void unloadBlock(TownBlock b) {
-        b.settings.setParent(null);
-        blocks.remove(b);
-    }
+	public void unloadResident(Resident r) {
+		/*
+		 * if (r.onlinePlayer == null && r.town() == null) residents.remove(r);
+		 */
+	}
 
-    public void unloadResident(Resident r) {
-        /*
-         * if (r.onlinePlayer == null && r.town() == null) residents.remove(r);
-         */
-    }
+	public int deleteAllTownBlocksInDimension(int dim) {
+		int ret = 0;
+		ArrayList<TownBlock> toRemove = new ArrayList<TownBlock>();
+		for (TownBlock res : blocks) {
+			if (res.worldDimension() == dim) {
+				toRemove.add(res);
+			}
+		}
 
-    public int deleteAllTownBlocksInDimension(int dim) {
-        int ret = 0;
-        ArrayList<TownBlock> toRemove = new ArrayList<TownBlock>();
-        for (TownBlock res : blocks) {
-            if (res.worldDimension() == dim) {
-                toRemove.add(res);
-            }
-        }
+		ArrayList<Town> townsToSave = new ArrayList<Town>();
+		for (TownBlock res : toRemove) {
+			if (res.town() != null) {
+				townsToSave.add(res.town());
+				res.town().removeBlockUnsafe(res);
+				ret++;
+			} else {
+				unloadBlock(res);
+			}
+		}
 
-        ArrayList<Town> townsToSave = new ArrayList<Town>();
-        for (TownBlock res : toRemove) {
-            if (res.town() != null) {
-                townsToSave.add(res.town());
-                res.town().removeBlockUnsafe(res);
-                ret++;
-            } else {
-                unloadBlock(res);
-            }
-        }
+		for (Town t : townsToSave) {
+			t.save();
+		}
 
-        for (Town t : townsToSave) {
-            t.save();
-        }
+		return ret;
+	}
 
-        return ret;
-    }
+	public List<Resident> getOldResidents(Date lastLoginTimeBelow) {
+		ArrayList<Resident> players = new ArrayList<Resident>();
+		synchronized (residents) {
+			for (Resident res : residents) {
+				if (res.town() != null && !res.isOnline() && res.lastLogin().compareTo(lastLoginTimeBelow) < 0) {
+					players.add(res);
+				}
+			}
+		}
 
-    public List<Resident> getOldResidents(Date lastLoginTimeBelow) {
-        ArrayList<Resident> players = new ArrayList<Resident>();
-        synchronized (residents) {
-            for (Resident res : residents) {
-                if (res.town() != null && !res.isOnline()
-                        && res.lastLogin().compareTo(lastLoginTimeBelow) < 0) {
-                    players.add(res);
-                }
-            }
-        }
+		return players;
+	}
 
-        return players;
-    }
+	public List<Town> getOldTowns(long lastLoginTimeBelow, double plotDaysAddition) {
+		ArrayList<Town> towns = new ArrayList<Town>();
+		synchronized (residents) {
+			for (Resident res : residents) {
+				Date last = new Date(lastLoginTimeBelow - (res.town() != null ? (int) (plotDaysAddition * res.town().blocks().size()) : 0));
+				if (res.town() != null && !res.isOnline() && res.lastLogin().compareTo(last) < 0) {
+					if (!towns.contains(res.town())) {
+						boolean allOld = true;
+						for (Resident r : res.town().residents()) {
+							if (r.isOnline() || r.lastLogin().compareTo(last) >= 0) {
+								allOld = false;
+								break;
+							}
+						}
+						if (allOld) {
+							towns.add(res.town());
+						}
+					}
+				}
+			}
+		}
 
-    public List<Town> getOldTowns(long lastLoginTimeBelow,
-            double plotDaysAddition) {
-        ArrayList<Town> towns = new ArrayList<Town>();
-        synchronized (residents) {
-            for (Resident res : residents) {
-                Date last = new Date(lastLoginTimeBelow
-                        - (res.town() != null ? (int) (plotDaysAddition * res
-                                .town().blocks().size()) : 0));
-                if (res.town() != null && !res.isOnline()
-                        && res.lastLogin().compareTo(last) < 0) {
-                    if (!towns.contains(res.town())) {
-                        boolean allOld = true;
-                        for (Resident r : res.town().residents()) {
-                            if (r.isOnline()
-                                    || r.lastLogin().compareTo(last) >= 0) {
-                                allOld = false;
-                                break;
-                            }
-                        }
-                        if (allOld) {
-                            towns.add(res.town());
-                        }
-                    }
-                }
-            }
-        }
-
-        return towns;
-    }
+		return towns;
+	}
 }

--- a/src/ee/lutsu/alpha/mc/mytown/MyTownDatasource.java
+++ b/src/ee/lutsu/alpha/mc/mytown/MyTownDatasource.java
@@ -22,11 +22,11 @@ public class MyTownDatasource extends MyTownDB {
 	public HashMap<String, TownBlock> blocks = new HashMap<String, TownBlock>();
 	public HashMap<String, Nation> nations = new HashMap<String, Nation>();
 	
-	public String getTownBlockKey(int dim, int x, int z) {
+	public static String getTownBlockKey(int dim, int x, int z) {
 		return dim + ";" + x + ";" + z;
 	}
 	
-	public String getTownBlockKey(TownBlock block) {
+	public static String getTownBlockKey(TownBlock block) {
 		return block.worldDimension() + ";" + block.x() + ";" + block.z();
 	}
 
@@ -158,11 +158,7 @@ public class MyTownDatasource extends MyTownDB {
 
 	public Resident getResident(String name) // case in-sensitive
 	{
-		long start = System.nanoTime();
 		Resident res = residents.get(name.toLowerCase());
-		long stop = System.nanoTime();
-		Log.info("getResident took: %d", stop - start);
-
 		return res;
 	}
 

--- a/src/ee/lutsu/alpha/mc/mytown/Term.java
+++ b/src/ee/lutsu/alpha/mc/mytown/Term.java
@@ -207,7 +207,7 @@ public enum Term {
             "You cannot be part of a town"), TownErrTownNameCannotBeEmpty(
             "Cannot set a empty name"), TownErrTownNameAlreadyInUse(
             "This town name has already need used"), TownErrNoFreeBlocks(
-            "You don't have any free blocks"),
+            "You don't have any free blocks"), TownErrNotAdjacent("Block is not adjacent to an already claimed block of this town"),
 
     ErrUnknowCommand(
             "§4Unknown command. Use tab for autocomplete or /t help to find correct commands. Commands are different based on your town rank."),

--- a/src/ee/lutsu/alpha/mc/mytown/commands/CmdMyTownAdmin.java
+++ b/src/ee/lutsu/alpha/mc/mytown/commands/CmdMyTownAdmin.java
@@ -125,7 +125,7 @@ public class CmdMyTownAdmin extends CommandBase {
                 }
 
                 int i = 0;
-                for (Resident r : MyTownDatasource.instance.residents) {
+                for (Resident r : MyTownDatasource.instance.residents.values()) {
                     if (r.activeChannel != ChatChannel.defaultChannel) {
                         i++;
                         r.setActiveChannel(ChatChannel.defaultChannel);

--- a/src/ee/lutsu/alpha/mc/mytown/commands/MyTownAssistant.java
+++ b/src/ee/lutsu/alpha/mc/mytown/commands/MyTownAssistant.java
@@ -58,7 +58,7 @@ public class MyTownAssistant {
             list.add(Term.TownCmdClaimArgs1.toString());
         } else if (args.length == 2
                 && args[0].equalsIgnoreCase(Term.TownCmdInvite.toString())) {
-            for (Resident r : MyTownDatasource.instance.residents) {
+            for (Resident r : MyTownDatasource.instance.residents.values()) {
                 if (r.town() == null) {
                     list.add(r.name());
                 }

--- a/src/ee/lutsu/alpha/mc/mytown/commands/MyTownAssistant.java
+++ b/src/ee/lutsu/alpha/mc/mytown/commands/MyTownAssistant.java
@@ -10,6 +10,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.Vec3;
 
 import com.google.common.collect.Lists;
+import com.sperion.forgeperms.ForgePerms;
 
 import ee.lutsu.alpha.mc.mytown.Assert;
 import ee.lutsu.alpha.mc.mytown.CommandException;
@@ -160,6 +161,10 @@ public class MyTownAssistant {
             int requestedBlocks = 0, ableToClaim = 0, alreadyOwn = 0;
             List<TownBlock> blocks = Lists.newArrayList();
 
+            boolean bypassFarawayRestriction = ForgePerms.getPermissionsHandler().canAccess(res.name(),
+                    res.onlinePlayer.worldObj.provider.getDimensionName(),
+                    "mytown.adm.bypass.faraway");
+            
             for (int z = cz - radius_rec; z <= cz + radius_rec; z++) {
                 for (int x = cx - radius_rec; x <= cx + radius_rec; x++) {
                     requestedBlocks++;
@@ -173,6 +178,9 @@ public class MyTownAssistant {
 
                     try {
                         Town.canAddBlock(b, false, res.town());
+                        if (!bypassFarawayRestriction && !Town.allowFarawayClaims && !res.town().blocks().isEmpty()) {
+                            Town.isBlockAdjacentToTown(b, res.town());
+                        }
                         ableToClaim++;
                         blocks.add(b);
                     } catch (CommandException e) {

--- a/src/ee/lutsu/alpha/mc/mytown/commands/MyTownAssistant.java
+++ b/src/ee/lutsu/alpha/mc/mytown/commands/MyTownAssistant.java
@@ -1,7 +1,9 @@
 package ee.lutsu.alpha.mc.mytown.commands;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 
 import net.minecraft.command.ICommandSender;
@@ -10,6 +12,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.Vec3;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.sperion.forgeperms.ForgePerms;
 
 import ee.lutsu.alpha.mc.mytown.Assert;
@@ -35,10 +38,8 @@ public class MyTownAssistant {
             return list;
         }
 
-        Resident res = MyTownDatasource.instance
-                .getOrMakeResident((EntityPlayer) cs);
-        if (res.town() == null || res.rank() != Rank.Mayor
-                && res.rank() != Rank.Assistant) {
+        Resident res = MyTownDatasource.instance.getOrMakeResident((EntityPlayer) cs);
+        if (res.town() == null || res.rank() != Rank.Mayor && res.rank() != Rank.Assistant) {
             return list;
         }
 
@@ -49,45 +50,35 @@ public class MyTownAssistant {
             list.add(Term.TownCmdKick.toString());
             list.add(Term.TownCmdSetSpawn.toString());
             list.add(Term.TownCmdPlot.toString());
-        } else if (args.length == 2
-                && (args[0].equals("?") || args[0]
-                        .equalsIgnoreCase(Term.CommandHelp.toString()))) {
+        } else if (args.length == 2 && (args[0].equals("?") || args[0].equalsIgnoreCase(Term.CommandHelp.toString()))) {
             list.add(Term.CommandHelpAssistant.toString());
         } else if (args.length == 2
-                && (args[0].equalsIgnoreCase(Term.TownCmdClaim.toString()) || args[0]
-                        .equalsIgnoreCase(Term.TownCmdUnclaim.toString()))) {
+                && (args[0].equalsIgnoreCase(Term.TownCmdClaim.toString()) || args[0].equalsIgnoreCase(Term.TownCmdUnclaim.toString()))) {
             list.add(Term.TownCmdClaimArgs1.toString());
-        } else if (args.length == 2
-                && args[0].equalsIgnoreCase(Term.TownCmdInvite.toString())) {
+        } else if (args.length == 2 && args[0].equalsIgnoreCase(Term.TownCmdInvite.toString())) {
             for (Resident r : MyTownDatasource.instance.residents.values()) {
                 if (r.town() == null) {
                     list.add(r.name());
                 }
             }
-        } else if (args.length == 2
-                && args[0].equalsIgnoreCase(Term.TownCmdKick.toString())) {
+        } else if (args.length == 2 && args[0].equalsIgnoreCase(Term.TownCmdKick.toString())) {
             for (Resident r : res.town().residents()) {
-                if (r != res
-                        && r.rank() != Rank.Mayor
-                        && (res.rank() == Rank.Mayor || r.rank() != Rank.Assistant)) {
+                if (r != res && r.rank() != Rank.Mayor && (res.rank() == Rank.Mayor || r.rank() != Rank.Assistant)) {
                     list.add(r.name());
                 }
             }
-        } else if (args.length == 2
-                && args[0].equalsIgnoreCase(Term.TownCmdPlot.toString())) {
+        } else if (args.length == 2 && args[0].equalsIgnoreCase(Term.TownCmdPlot.toString())) {
             for (Resident r : res.town().residents()) {
                 list.add(r.name());
             }
-        } else if (args.length == 3
-                && args[0].equalsIgnoreCase(Term.TownCmdPlot.toString())) {
+        } else if (args.length == 3 && args[0].equalsIgnoreCase(Term.TownCmdPlot.toString())) {
             list.add("rect");
         }
 
         return list;
     }
 
-    public static boolean handleCommand(ICommandSender cs, String[] args)
-            throws CommandException, NoAccessException {
+    public static boolean handleCommand(ICommandSender cs, String[] args) throws CommandException, NoAccessException {
         if (args.length < 1) {
             return false;
         }
@@ -96,42 +87,29 @@ public class MyTownAssistant {
             return false;
         }
 
-        Resident res = MyTownDatasource.instance
-                .getOrMakeResident((EntityPlayer) cs);
-        if (res.town() == null || res.rank() != Rank.Mayor
-                && res.rank() != Rank.Assistant) {
+        Resident res = MyTownDatasource.instance.getOrMakeResident((EntityPlayer) cs);
+        if (res.town() == null || res.rank() != Rank.Mayor && res.rank() != Rank.Assistant) {
             return false;
         }
 
         boolean handled = false;
         String color = "6";
-        if (args[0].equals("?")
-                || args[0].equalsIgnoreCase(Term.CommandHelp.toString())) {
+        if (args[0].equals("?") || args[0].equalsIgnoreCase(Term.CommandHelp.toString())) {
             if (args.length < 2) {
-                cs.sendChatToPlayer(Formatter.formatGroupCommand(
-                        Term.CommandHelp.toString(), Term.CommandHelpAssistant
-                                .toString(), Term.CommandHelpAssistantDesc
-                                .toString(), color));
+                cs.sendChatToPlayer(Formatter.formatGroupCommand(Term.CommandHelp.toString(), Term.CommandHelpAssistant.toString(),
+                        Term.CommandHelpAssistantDesc.toString(), color));
                 handled = true;
-            } else if (args[1].equalsIgnoreCase(Term.CommandHelpAssistant
-                    .toString())) {
-                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdClaim
-                        .toString(), Term.TownCmdClaimArgs.toString(),
+            } else if (args[1].equalsIgnoreCase(Term.CommandHelpAssistant.toString())) {
+                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdClaim.toString(), Term.TownCmdClaimArgs.toString(),
                         Term.TownCmdClaimDesc.toString(), color));
-                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdUnclaim
-                        .toString(), Term.TownCmdUnclaimArgs.toString(),
+                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdUnclaim.toString(), Term.TownCmdUnclaimArgs.toString(),
                         Term.TownCmdUnclaimDesc.toString(), color));
-                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdInvite
-                        .toString(), Term.TownCmdInviteArgs.toString(),
+                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdInvite.toString(), Term.TownCmdInviteArgs.toString(),
                         Term.TownCmdInviteDesc.toString(), color));
-                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdKick
-                        .toString(), Term.TownCmdKickArgs.toString(),
+                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdKick.toString(), Term.TownCmdKickArgs.toString(),
                         Term.TownCmdKickDesc.toString(), color));
-                cs.sendChatToPlayer(Formatter.formatCommand(
-                        Term.TownCmdSetSpawn.toString(), "",
-                        Term.TownCmdSetSpawnDesc.toString(), color));
-                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdPlot
-                        .toString(), Term.TownCmdPlotArgs.toString(),
+                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdSetSpawn.toString(), "", Term.TownCmdSetSpawnDesc.toString(), color));
+                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdPlot.toString(), Term.TownCmdPlotArgs.toString(),
                         Term.TownCmdPlotDesc.toString(), color));
                 handled = true;
             }
@@ -139,7 +117,7 @@ public class MyTownAssistant {
             if (res.onlinePlayer == null) {
                 throw new NullPointerException("Onlineplayer is null");
             }
-            int dim = res.onlinePlayer.dimension;
+            int dim = res.onlinePlayer.worldObj.provider.dimensionId;
 
             Assert.Perm(cs, "mytown.cmd.claim.dim" + dim);
             handled = true;
@@ -149,8 +127,7 @@ public class MyTownAssistant {
                 if (args[1].equalsIgnoreCase(Term.TownCmdClaimArgs1.toString())) {
                     radius_rec = Integer.parseInt(args[2]);
                 } else {
-                    throw new CommandException(Term.TownErrCmdUnknownArgument,
-                            args[1]);
+                    throw new CommandException(Term.TownErrCmdUnknownArgument, args[1]);
                 }
             }
 
@@ -162,15 +139,13 @@ public class MyTownAssistant {
             List<TownBlock> blocks = Lists.newArrayList();
 
             boolean bypassFarawayRestriction = ForgePerms.getPermissionsHandler().canAccess(res.name(),
-                    res.onlinePlayer.worldObj.provider.getDimensionName(),
-                    "mytown.adm.bypass.faraway");
-            
+                    res.onlinePlayer.worldObj.provider.getDimensionName(), "mytown.adm.bypass.faraway");
+
             for (int z = cz - radius_rec; z <= cz + radius_rec; z++) {
                 for (int x = cx - radius_rec; x <= cx + radius_rec; x++) {
                     requestedBlocks++;
 
-                    TownBlock b = MyTownDatasource.instance.getOrMakeBlock(dim,
-                            x, z);
+                    TownBlock b = MyTownDatasource.instance.getOrMakeBlock(dim, x, z);
                     if (b.town() == res.town()) {
                         alreadyOwn++;
                         continue;
@@ -178,9 +153,6 @@ public class MyTownAssistant {
 
                     try {
                         Town.canAddBlock(b, false, res.town());
-                        if (!bypassFarawayRestriction && !Town.allowFarawayClaims && !res.town().blocks().isEmpty()) {
-                            Town.isBlockAdjacentToTown(b, res.town());
-                        }
                         ableToClaim++;
                         blocks.add(b);
                     } catch (CommandException e) {
@@ -195,12 +167,63 @@ public class MyTownAssistant {
                 }
             }
 
-            cs.sendChatToPlayer(Term.TownBlocksClaimedDisclaimer.toString(
-                    requestedBlocks, ableToClaim, alreadyOwn));
+            boolean noChunksInDim = true;
+            for (TownBlock block : res.town().blocks()) {
+                if (block.worldDimension() == dim) {
+                    noChunksInDim = false;
+                    break;
+                }
+            }
+
+            // throw new CommandException(Term.TownErrNotAdjacent);
+
+            // Does new claim have to be adjacent to existing claims?
+            if (!bypassFarawayRestriction && !Town.allowFarawayClaims && !noChunksInDim) {
+                Map<String, TownBlock> adjacentBlocksMap = Maps.newHashMap();
+                List<TownBlock> adjacentBlocks = Lists.newArrayList();
+
+                // First check, grab all chunks adjacent to existing town chunks
+                for (TownBlock block : blocks) {
+                    if (Town.isBlockAdjacentToTown(block, res.town())) {
+                        adjacentBlocksMap.put(MyTownDatasource.getTownBlockKey(block), block);
+                        adjacentBlocks.add(block);
+                    }
+                }
+                blocks.removeAll(adjacentBlocks);
+                
+
+                // Not all blocks are immediatly adjacent, need to iterate
+                if (blocks.size() > 0) {
+                    boolean addedBlocks = false;
+                    do {
+                        addedBlocks = false;
+                        for (TownBlock block : blocks) {
+                            if (Town.isBlockAdjacentToBlocks(block, adjacentBlocksMap)) {
+                                adjacentBlocksMap.put(MyTownDatasource.getTownBlockKey(block), block);
+                                ableToClaim--;
+                                adjacentBlocks.add(block);
+                                addedBlocks = true;
+                            }
+                        }
+                        blocks.removeAll(adjacentBlocks);
+                    } while (addedBlocks);
+                }
+
+                // Blocks that couldn't be added due to adjacent requirements
+                if (!blocks.isEmpty()) {
+                    for (TownBlock b : blocks) {
+                        if (b.town() == null) {
+                            MyTownDatasource.instance.unloadBlock(b);
+                        }
+                    }
+                }
+                blocks = adjacentBlocks;
+                ableToClaim = blocks.size();
+            }
+
+            cs.sendChatToPlayer(Term.TownBlocksClaimedDisclaimer.toString(requestedBlocks, ableToClaim, alreadyOwn));
             if (firstError != null) {
-                cs.sendChatToPlayer(Term.TownBlocksClaimedDisclaimer2
-                        .toString(firstError.errorCode
-                                .toString(firstError.args)));
+                cs.sendChatToPlayer(Term.TownBlocksClaimedDisclaimer2.toString(firstError.errorCode.toString(firstError.args)));
             }
 
             if (blocks.size() > 0) {
@@ -211,39 +234,33 @@ public class MyTownAssistant {
                     request.stackSize = request.stackSize * blocks.size();
                 }
 
-                res.pay.requestPayment("townclaimblock", request,
-                        new PayHandler.IDone() {
-                            @Override
-                            public void run(Resident res, Object[] args) {
-                                StringBuilder sb = new StringBuilder();
-                                int nr = 0;
-                                List<TownBlock> blocks = (List<TownBlock>) args[0];
+                res.pay.requestPayment("townclaimblock", request, new PayHandler.IDone() {
+                    @Override
+                    public void run(Resident res, Object[] args) {
+                        StringBuilder sb = new StringBuilder();
+                        int nr = 0;
+                        List<TownBlock> blocks = (List<TownBlock>) args[0];
 
-                                for (TownBlock b : blocks) {
-                                    try {
-                                        res.town().addBlock(b);
+                        for (TownBlock b : blocks) {
+                            try {
+                                res.town().addBlock(b);
 
-                                        nr++;
-                                        if (sb.length() > 0) {
-                                            sb.append(", ");
-                                        }
-
-                                        sb.append(String.format("(%s,%s)", b
-                                                .x(), b.z()));
-                                    } catch (CommandException e) {
-                                        Log.severe(
-                                                "Block claiming failed after payment",
-                                                e);
-                                    }
+                                nr++;
+                                if (sb.length() > 0) {
+                                    sb.append(", ");
                                 }
 
-                                res.checkLocation(); // emulate that the player
-                                                     // just entered it
-                                res.onlinePlayer
-                                        .sendChatToPlayer(Term.TownBlocksClaimed
-                                                .toString(nr, sb.toString()));
+                                sb.append(String.format("(%s,%s)", b.x(), b.z()));
+                            } catch (CommandException e) {
+                                Log.severe("Block claiming failed after payment", e);
                             }
-                        }, blocks);
+                        }
+
+                        res.checkLocation(); // emulate that the player
+                                             // just entered it
+                        res.onlinePlayer.sendChatToPlayer(Term.TownBlocksClaimed.toString(nr, sb.toString()));
+                    }
+                }, blocks);
             }
         } else if (args[0].equalsIgnoreCase(Term.TownCmdUnclaim.toString())) {
             Assert.Perm(cs, "mytown.cmd.unclaim");
@@ -255,12 +272,10 @@ public class MyTownAssistant {
 
             int radius_rec = 0;
             if (args.length > 1) {
-                if (args[1].equalsIgnoreCase(Term.TownCmdUnclaimArgs1
-                        .toString())) {
+                if (args[1].equalsIgnoreCase(Term.TownCmdUnclaimArgs1.toString())) {
                     radius_rec = Integer.parseInt(args[2]);
                 } else {
-                    throw new CommandException(Term.TownErrCmdUnknownArgument,
-                            args[1]);
+                    throw new CommandException(Term.TownErrCmdUnknownArgument, args[1]);
                 }
             }
 
@@ -298,30 +313,25 @@ public class MyTownAssistant {
 
             // emulate that the player just entered it
             res.checkLocation();
-            cs.sendChatToPlayer(Term.TownBlocksUnclaimed.toString(nr, sb
-                    .toString()));
+            cs.sendChatToPlayer(Term.TownBlocksUnclaimed.toString(nr, sb.toString()));
         } else if (args[0].equalsIgnoreCase(Term.TownCmdInvite.toString())) {
             Assert.Perm(cs, "mytown.cmd.invite");
             handled = true;
 
             if (args.length < 2) {
-                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdInvite
-                        .toString(), Term.TownCmdInviteArgs.toString(),
+                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdInvite.toString(), Term.TownCmdInviteArgs.toString(),
                         Term.TownCmdInviteDesc.toString(), color));
             } else {
-                Resident target = MyTownDatasource.instance
-                        .getResident(args[1]);
+                Resident target = MyTownDatasource.instance.getResident(args[1]);
                 if (target == null || target.onlinePlayer == null) {
-                    throw new CommandException(
-                            Term.TownErrPlayerNotFoundOrOnline);
+                    throw new CommandException(Term.TownErrPlayerNotFoundOrOnline);
                 }
 
                 if (target == res) {
                     throw new CommandException(Term.TownErrInvitationSelf);
                 }
                 if (target.town() == res.town()) {
-                    throw new CommandException(
-                            Term.TownErrInvitationAlreadyInYourTown);
+                    throw new CommandException(Term.TownErrInvitationAlreadyInYourTown);
                 }
                 if (target.town() != null) {
                     throw new CommandException(Term.TownErrInvitationInTown);
@@ -332,22 +342,18 @@ public class MyTownAssistant {
 
                 target.inviteActiveFrom = res.town();
 
-                target.onlinePlayer.sendChatToPlayer(Term.TownInvitation
-                        .toString(res.name(), res.town().name()));
-                cs.sendChatToPlayer(Term.TownInvitedPlayer.toString(target
-                        .name()));
+                target.onlinePlayer.sendChatToPlayer(Term.TownInvitation.toString(res.name(), res.town().name()));
+                cs.sendChatToPlayer(Term.TownInvitedPlayer.toString(target.name()));
             }
         } else if (args[0].equalsIgnoreCase(Term.TownCmdKick.toString())) {
             Assert.Perm(cs, "mytown.cmd.kick");
             handled = true;
 
             if (args.length < 2) {
-                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdKick
-                        .toString(), Term.TownCmdKickArgs.toString(),
+                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdKick.toString(), Term.TownCmdKickArgs.toString(),
                         Term.TownCmdKickDesc.toString(), color));
             } else {
-                Resident target = MyTownDatasource.instance
-                        .getResident(args[1]);
+                Resident target = MyTownDatasource.instance.getResident(args[1]);
 
                 if (target == null) {
                     throw new CommandException(Term.TownErrPlayerNotFound);
@@ -362,25 +368,20 @@ public class MyTownAssistant {
                 if (target.rank() == Rank.Mayor && res.rank() == Rank.Assistant) {
                     throw new CommandException(Term.TownErrCannotKickMayor);
                 }
-                if (target.rank() == Rank.Assistant
-                        && res.rank() == Rank.Assistant) {
+                if (target.rank() == Rank.Assistant && res.rank() == Rank.Assistant) {
                     throw new CommandException(Term.TownErrCannotKickAssistants);
                 }
 
                 res.town().removeResident(target);
 
-                res.town().sendNotification(
-                        Level.INFO,
-                        Term.TownKickedPlayer.toString(res.name(), target
-                                .name()));
+                res.town().sendNotification(Level.INFO, Term.TownKickedPlayer.toString(res.name(), target.name()));
             }
         } else if (args[0].equalsIgnoreCase(Term.TownCmdPlot.toString())) {
             Assert.Perm(cs, "mytown.cmd.plot");
             handled = true;
 
             if (args.length < 2) {
-                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdPlot
-                        .toString(), Term.TownCmdPlotArgs.toString(),
+                cs.sendChatToPlayer(Formatter.formatCommand(Term.TownCmdPlot.toString(), Term.TownCmdPlotArgs.toString(),
                         Term.TownCmdPlotDesc.toString(), color));
             } else {
                 int radius_rec = 0;
@@ -388,23 +389,19 @@ public class MyTownAssistant {
                     if (args[2].equalsIgnoreCase("rect")) {
                         radius_rec = Integer.parseInt(args[3]);
                     } else {
-                        throw new CommandException(
-                                Term.TownErrCmdUnknownArgument, args[2]);
+                        throw new CommandException(Term.TownErrCmdUnknownArgument, args[2]);
                     }
                 }
 
                 Resident target = null;
 
-                if (args[1] != null && !args[1].equals("")
-                        && !args[1].equalsIgnoreCase("none")
-                        && !args[1].equalsIgnoreCase("null")) {
+                if (args[1] != null && !args[1].equals("") && !args[1].equalsIgnoreCase("none") && !args[1].equalsIgnoreCase("null")) {
                     target = MyTownDatasource.instance.getResident(args[1]);
                     if (target == null) {
                         throw new CommandException(Term.TownErrPlayerNotFound);
                     }
                     if (res.town() != target.town()) {
-                        throw new CommandException(
-                                Term.TownErrPlayerNotInYourTown);
+                        throw new CommandException(Term.TownErrPlayerNotInYourTown);
                     }
                 }
 
@@ -413,15 +410,12 @@ public class MyTownAssistant {
                 int cz = res.onlinePlayer.chunkCoordZ;
                 for (int z = cz - radius_rec; z <= cz + radius_rec; z++) {
                     for (int x = cx - radius_rec; x <= cx + radius_rec; x++) {
-                        TownBlock b = MyTownDatasource.instance.getBlock(
-                                res.onlinePlayer.dimension, x, z);
+                        TownBlock b = MyTownDatasource.instance.getBlock(res.onlinePlayer.dimension, x, z);
                         if (b == null || b.town() == null) {
-                            throw new CommandException(
-                                    Term.ErrPermPlotNotInTown);
+                            throw new CommandException(Term.ErrPermPlotNotInTown);
                         }
                         if (b.town() != res.town()) {
-                            throw new CommandException(
-                                    Term.ErrPermPlotNotInYourTown);
+                            throw new CommandException(Term.ErrPermPlotNotInYourTown);
                         }
 
                         if (b.owner() == target) {
@@ -442,8 +436,7 @@ public class MyTownAssistant {
                 }
 
                 if (target != null) {
-                    cs.sendChatToPlayer(Term.TownPlotAssigned.toString(target
-                            .name()));
+                    cs.sendChatToPlayer(Term.TownPlotAssigned.toString(target.name()));
                 } else {
                     cs.sendChatToPlayer(Term.TownPlotUnAssigned.toString());
                 }
@@ -452,8 +445,7 @@ public class MyTownAssistant {
             Assert.Perm(cs, "mytown.cmd.setspawn");
             handled = true;
 
-            TownBlock b = MyTownDatasource.instance.getBlock(
-                    res.onlinePlayer.dimension, res.onlinePlayer.chunkCoordX,
+            TownBlock b = MyTownDatasource.instance.getBlock(res.onlinePlayer.dimension, res.onlinePlayer.chunkCoordX,
                     res.onlinePlayer.chunkCoordZ);
 
             if (b == null || b.town() == null) {
@@ -463,10 +455,8 @@ public class MyTownAssistant {
                 throw new CommandException(Term.ErrPermPlotNotInYourTown);
             }
 
-            Vec3 vec = Vec3.createVectorHelper(res.onlinePlayer.posX,
-                    res.onlinePlayer.posY, res.onlinePlayer.posZ);
-            res.town().setSpawn(b, vec, res.onlinePlayer.rotationPitch,
-                    res.onlinePlayer.rotationYaw);
+            Vec3 vec = Vec3.createVectorHelper(res.onlinePlayer.posX, res.onlinePlayer.posY, res.onlinePlayer.posZ);
+            res.town().setSpawn(b, vec, res.onlinePlayer.rotationPitch, res.onlinePlayer.rotationYaw);
 
             cs.sendChatToPlayer(Term.TownSpawnSet.toString());
         }

--- a/src/ee/lutsu/alpha/mc/mytown/commands/MyTownEveryone.java
+++ b/src/ee/lutsu/alpha/mc/mytown/commands/MyTownEveryone.java
@@ -43,7 +43,7 @@ public class MyTownEveryone {
             }
         } else if (args.length == 2
                 && args[0].equalsIgnoreCase(Term.TownCmdRes.toString())) {
-            for (Resident r : MyTownDatasource.instance.residents) {
+            for (Resident r : MyTownDatasource.instance.residents.values()) {
                 list.add(r.name());
             }
         } else if (args.length == 2
@@ -60,7 +60,7 @@ public class MyTownEveryone {
                     .getOrMakeResident((EntityPlayer) cs);
             String cmd = args[1];
 
-            for (Resident r : MyTownDatasource.instance.residents) {
+            for (Resident r : MyTownDatasource.instance.residents.values()) {
                 if (cmd.equalsIgnoreCase(Term.TownCmdFriendArgsAdd.toString())
                         && res.friends.contains(r)) {
                     continue;

--- a/src/ee/lutsu/alpha/mc/mytown/commands/MyTownEveryone.java
+++ b/src/ee/lutsu/alpha/mc/mytown/commands/MyTownEveryone.java
@@ -38,7 +38,7 @@ public class MyTownEveryone {
         } else if (args.length == 2
                 && (args[0].equalsIgnoreCase(Term.TownCmdInfo.toString()) || args[0]
                         .equalsIgnoreCase(Term.TownCmdSpawn.toString()))) {
-            for (Town t : MyTownDatasource.instance.towns) {
+            for (Town t : MyTownDatasource.instance.towns.values()) {
                 list.add(t.name());
             }
         } else if (args.length == 2
@@ -283,7 +283,7 @@ public class MyTownEveryone {
             handled = true;
 
             ArrayList<Town> sorted = new ArrayList<Town>(
-                    MyTownDatasource.instance.towns);
+                    MyTownDatasource.instance.towns.values());
 
             Collections.sort(sorted, new Comparator<Town>() {
                 @Override

--- a/src/ee/lutsu/alpha/mc/mytown/commands/MyTownNation.java
+++ b/src/ee/lutsu/alpha/mc/mytown/commands/MyTownNation.java
@@ -39,7 +39,7 @@ public class MyTownNation {
             } else if (args.length == 3
                     && args[1].equalsIgnoreCase(Term.TownCmdNationInfo
                             .toString())) {
-                for (Nation n : MyTownDatasource.instance.nations) {
+                for (Nation n : MyTownDatasource.instance.nations.values()) {
                     list.add(n.name());
                 }
             }
@@ -81,7 +81,7 @@ public class MyTownNation {
                                 && args[1]
                                         .equalsIgnoreCase(Term.TownCmdNationInvite
                                                 .toString())) {
-                            for (Town n : MyTownDatasource.instance.towns) {
+                            for (Town n : MyTownDatasource.instance.towns.values()) {
                                 if (n.nation() == null) {
                                     list.add(n.name());
                                 }
@@ -191,7 +191,7 @@ public class MyTownNation {
             handled = true;
 
             ArrayList<Nation> sorted = new ArrayList<Nation>(
-                    MyTownDatasource.instance.nations);
+                    MyTownDatasource.instance.nations.values());
 
             Collections.sort(sorted, new Comparator<Nation>() {
                 @Override

--- a/src/ee/lutsu/alpha/mc/mytown/entities/Nation.java
+++ b/src/ee/lutsu/alpha/mc/mytown/entities/Nation.java
@@ -75,10 +75,9 @@ public class Nation {
             throw new CommandException(Term.TownErrNationNameCannotBeEmpty);
         }
 
-        for (Nation n : MyTownDatasource.instance.nations) {
-            if (n != this && n.name.equalsIgnoreCase(name)) {
-                throw new CommandException(Term.TownErrNationNameInUse);
-            }
+        Nation n = MyTownDatasource.instance.nations.get(name);
+        if (n != this) {
+            throw new CommandException(Term.TownErrNationNameInUse);
         }
     }
 

--- a/src/ee/lutsu/alpha/mc/mytown/entities/Nation.java
+++ b/src/ee/lutsu/alpha/mc/mytown/entities/Nation.java
@@ -75,8 +75,8 @@ public class Nation {
             throw new CommandException(Term.TownErrNationNameCannotBeEmpty);
         }
 
-        Nation n = MyTownDatasource.instance.nations.get(name);
-        if (n != this) {
+        Nation n = MyTownDatasource.instance.nations.get(name.toLowerCase());
+        if (n != null && n != this) {
             throw new CommandException(Term.TownErrNationNameInUse);
         }
     }

--- a/src/ee/lutsu/alpha/mc/mytown/entities/Resident.java
+++ b/src/ee/lutsu/alpha/mc/mytown/entities/Resident.java
@@ -829,7 +829,7 @@ public class Resident {
             fnames.add(Formatter.formatResidentName(r));
         }
 
-        for (Resident r : MyTownDatasource.instance.residents) {
+        for (Resident r : MyTownDatasource.instance.residents.values()) {
             if (r.friends.contains(this)) {
                 fnames2.add(Formatter.formatResidentName(r));
             }

--- a/src/ee/lutsu/alpha/mc/mytown/entities/Town.java
+++ b/src/ee/lutsu/alpha/mc/mytown/entities/Town.java
@@ -2,6 +2,7 @@ package ee.lutsu.alpha.mc.mytown.entities;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 
 import net.minecraft.command.ICommandSender;
@@ -323,20 +324,38 @@ public class Town {
         }
     }
 
-    public static void isBlockAdjacentToTown(TownBlock block, Town town) throws CommandException {
+    public static boolean isBlockAdjacentToTown(TownBlock block, Town town)  {
         
         TownBlock adjacent;
         
         adjacent = MyTownDatasource.instance.getBlock(block.worldDimension(), block.x()-1, block.z());
-        if (adjacent != null && adjacent.town() == town) return;
+        if (adjacent != null && adjacent.town() == town) return true;
         adjacent = MyTownDatasource.instance.getBlock(block.worldDimension(), block.x()+1, block.z());
-        if (adjacent != null && adjacent.town() == town) return;
+        if (adjacent != null && adjacent.town() == town) return true;
         adjacent = MyTownDatasource.instance.getBlock(block.worldDimension(), block.x(), block.z()-1);
-        if (adjacent != null && adjacent.town() == town) return;
+        if (adjacent != null && adjacent.town() == town) return true;
         adjacent = MyTownDatasource.instance.getBlock(block.worldDimension(), block.x(), block.z()+1);
-        if (adjacent != null && adjacent.town() == town) return;
+        if (adjacent != null && adjacent.town() == town) return true;
         
-        throw new CommandException(Term.TownErrBlockTooCloseToAnotherTown);
+        return false;
+       
+    }
+    
+    public static boolean isBlockAdjacentToBlocks(TownBlock block, Map<String, TownBlock> blocks)  {
+        
+        TownBlock adjacent;
+        
+        adjacent = blocks.get(MyTownDatasource.getTownBlockKey(block.worldDimension(), block.x()-1, block.z()));
+        if (adjacent != null) return true;
+        adjacent = blocks.get(MyTownDatasource.getTownBlockKey(block.worldDimension(), block.x()+1, block.z()));
+        if (adjacent != null) return true;
+        adjacent = blocks.get(MyTownDatasource.getTownBlockKey(block.worldDimension(), block.x(), block.z()-1));
+        if (adjacent != null) return true;
+        adjacent = blocks.get(MyTownDatasource.getTownBlockKey(block.worldDimension(), block.x(), block.z()+1));
+        if (adjacent != null) return true;
+        
+        return false;
+       
     }
 
     public void addBlock(TownBlock block) throws CommandException {

--- a/src/ee/lutsu/alpha/mc/mytown/entities/Town.java
+++ b/src/ee/lutsu/alpha/mc/mytown/entities/Town.java
@@ -320,7 +320,7 @@ public class Town {
         }
 
         int sqr = minDistanceFromOtherTown * minDistanceFromOtherTown;
-        for (TownBlock b : MyTownDatasource.instance.blocks) {
+        for (TownBlock b : MyTownDatasource.instance.blocks.values()) {
             if (b != block
                     && b.town() != null
                     && b.town() != self

--- a/src/ee/lutsu/alpha/mc/mytown/entities/Town.java
+++ b/src/ee/lutsu/alpha/mc/mytown/entities/Town.java
@@ -23,6 +23,7 @@ import ee.lutsu.alpha.mc.mytown.entities.TownSettingCollection.ISettingsSaveHand
 
 public class Town {
     public static int minDistanceFromOtherTown = 5;
+    public static boolean allowFarawayClaims = true;
     public static int dontSendCartNotification = 5000;
     public static boolean allowFullPvp = false;
     public static boolean allowMemberToForeignPvp = true;
@@ -119,8 +120,7 @@ public class Town {
         save();
     }
 
-    public static void assertNewTownParams(String pName, Resident creator,
-            TownBlock home) throws CommandException {
+    public static void assertNewTownParams(String pName, Resident creator, TownBlock home) throws CommandException {
         if (creator.town() != null) {
             throw new CommandException(Term.TownErrCreatorPartOfTown);
         }
@@ -131,8 +131,7 @@ public class Town {
         }
     }
 
-    public Town(String pName, Resident creator, TownBlock home)
-            throws CommandException {
+    public Town(String pName, Resident creator, TownBlock home) throws CommandException {
         assertNewTownParams(pName, creator, home);
 
         id = -1;
@@ -159,8 +158,7 @@ public class Town {
     /**
      * Used by SQL loading
      */
-    public Town(int pId, String pName, int pExtraBlocks,
-            List<TownBlock> pBlocks, String extra) {
+    public Town(int pId, String pName, int pExtraBlocks, List<TownBlock> pBlocks, String extra) {
         id = pId;
         name = pName;
         extraBlocks = pExtraBlocks;
@@ -204,31 +202,31 @@ public class Town {
 
         if (ForgePerms.getPermissionsHandler().canAccess(mayor.name(),
                 DimensionManager.getProvider(mayor.prevDimension).getDimensionName(),
-                //mayor.onlinePlayer.worldObj.provider.getDimensionName(),
+                // mayor.onlinePlayer.worldObj.provider.getDimensionName(),
                 "mytown.mayor.blocks.32")) {
             return 32;
         }
         if (ForgePerms.getPermissionsHandler().canAccess(mayor.name(),
                 DimensionManager.getProvider(mayor.prevDimension).getDimensionName(),
-                //mayor.onlinePlayer.worldObj.provider.getDimensionName(),
+                // mayor.onlinePlayer.worldObj.provider.getDimensionName(),
                 "mytown.mayor.blocks.16")) {
             return 16;
         }
         if (ForgePerms.getPermissionsHandler().canAccess(mayor.name(),
                 DimensionManager.getProvider(mayor.prevDimension).getDimensionName(),
-                //mayor.onlinePlayer.worldObj.provider.getDimensionName(),
+                // mayor.onlinePlayer.worldObj.provider.getDimensionName(),
                 "mytown.mayor.blocks.8")) {
             return 8;
         }
         if (ForgePerms.getPermissionsHandler().canAccess(mayor.name(),
                 DimensionManager.getProvider(mayor.prevDimension).getDimensionName(),
-                //mayor.onlinePlayer.worldObj.provider.getDimensionName(),
+                // mayor.onlinePlayer.worldObj.provider.getDimensionName(),
                 "mytown.mayor.blocks.4")) {
             return 4;
         }
         if (ForgePerms.getPermissionsHandler().canAccess(mayor.name(),
                 DimensionManager.getProvider(mayor.prevDimension).getDimensionName(),
-                //mayor.onlinePlayer.worldObj.provider.getDimensionName(),
+                // mayor.onlinePlayer.worldObj.provider.getDimensionName(),
                 "mytown.mayor.blocks.2")) {
             return 2;
         }
@@ -241,27 +239,23 @@ public class Town {
             return 1;
         }
 
-        if (ForgePerms.getPermissionsHandler().canAccess(res.name(),
-                DimensionManager.getProvider(res.prevDimension).getDimensionName(),
-                //res.onlinePlayer.worldObj.provider.getDimensionName(),
+        if (ForgePerms.getPermissionsHandler().canAccess(res.name(), DimensionManager.getProvider(res.prevDimension).getDimensionName(),
+        // res.onlinePlayer.worldObj.provider.getDimensionName(),
                 "mytown.resident.blocksmulti.10")) {
             return 10;
         }
-        if (ForgePerms.getPermissionsHandler().canAccess(res.name(),
-                DimensionManager.getProvider(res.prevDimension).getDimensionName(),
-                //res.onlinePlayer.worldObj.provider.getDimensionName(),
+        if (ForgePerms.getPermissionsHandler().canAccess(res.name(), DimensionManager.getProvider(res.prevDimension).getDimensionName(),
+        // res.onlinePlayer.worldObj.provider.getDimensionName(),
                 "mytown.resident.blocksmulti.8")) {
             return 8;
         }
-        if (ForgePerms.getPermissionsHandler().canAccess(res.name(),
-                DimensionManager.getProvider(res.prevDimension).getDimensionName(),
-                //res.onlinePlayer.worldObj.provider.getDimensionName(),
+        if (ForgePerms.getPermissionsHandler().canAccess(res.name(), DimensionManager.getProvider(res.prevDimension).getDimensionName(),
+        // res.onlinePlayer.worldObj.provider.getDimensionName(),
                 "mytown.resident.blocksmulti.4")) {
             return 4;
         }
-        if (ForgePerms.getPermissionsHandler().canAccess(res.name(),
-                DimensionManager.getProvider(res.prevDimension).getDimensionName(),
-                //res.onlinePlayer.worldObj.provider.getDimensionName(),
+        if (ForgePerms.getPermissionsHandler().canAccess(res.name(), DimensionManager.getProvider(res.prevDimension).getDimensionName(),
+        // res.onlinePlayer.worldObj.provider.getDimensionName(),
                 "mytown.resident.blocksmulti.2")) {
             return 2;
         }
@@ -280,8 +274,7 @@ public class Town {
     }
 
     public int totalBlocks() {
-        return perResidentBlocks() + extraBlocks
-                + (nation() == null ? 0 : nation().getTotalExtraBlocks(this));
+        return perResidentBlocks() + extraBlocks + (nation() == null ? 0 : nation().getTotalExtraBlocks(this));
     }
 
     public int freeBlocks() {
@@ -300,37 +293,28 @@ public class Town {
         save();
     }
 
-    public static void canSetName(String name, Town self)
-            throws CommandException {
+    public static void canSetName(String name, Town self) throws CommandException {
         if (name == null || name.equals("")) {
             throw new CommandException(Term.TownErrTownNameCannotBeEmpty);
         }
 
-        for (Town t : MyTownDatasource.instance.towns) {
-            if (t != self && t.name.equalsIgnoreCase(name)) {
-                throw new CommandException(Term.TownErrTownNameAlreadyInUse);
-            }
+        Town t = MyTownDatasource.instance.towns.get(name);
+        if (t != self) {
+            throw new CommandException(Term.TownErrTownNameAlreadyInUse);
         }
     }
 
-    public static void canAddBlock(TownBlock block, boolean ignoreRoomCheck,
-            Town self) throws CommandException {
+    public static void canAddBlock(TownBlock block, boolean ignoreRoomCheck, Town self) throws CommandException {
         if (block.town() != null) {
             throw new CommandException(Term.TownErrAlreadyClaimed);
         }
 
         int sqr = minDistanceFromOtherTown * minDistanceFromOtherTown;
         for (TownBlock b : MyTownDatasource.instance.blocks.values()) {
-            if (b != block
-                    && b.town() != null
-                    && b.town() != self
-                    && b.worldDimension() == block.worldDimension()
-                    && (b.town().nation() == null || self != null
-                            && b.town().nation() != self.nation())
-                    && block.squaredDistanceTo(b) <= sqr
-                    && !b.settings.allowClaimingNextTo) {
-                throw new CommandException(
-                        Term.TownErrBlockTooCloseToAnotherTown);
+            if (b != block && b.town() != null && b.town() != self && b.worldDimension() == block.worldDimension()
+                    && (b.town().nation() == null || self != null && b.town().nation() != self.nation())
+                    && block.squaredDistanceTo(b) <= sqr && !b.settings.allowClaimingNextTo) {
+                throw new CommandException(Term.TownErrBlockTooCloseToAnotherTown);
             }
         }
 
@@ -339,12 +323,27 @@ public class Town {
         }
     }
 
+    public static void isBlockAdjacentToTown(TownBlock block, Town town) throws CommandException {
+        
+        TownBlock adjacent;
+        
+        adjacent = MyTownDatasource.instance.getBlock(block.worldDimension(), block.x()-1, block.z());
+        if (adjacent != null && adjacent.town() == town) return;
+        adjacent = MyTownDatasource.instance.getBlock(block.worldDimension(), block.x()+1, block.z());
+        if (adjacent != null && adjacent.town() == town) return;
+        adjacent = MyTownDatasource.instance.getBlock(block.worldDimension(), block.x(), block.z()-1);
+        if (adjacent != null && adjacent.town() == town) return;
+        adjacent = MyTownDatasource.instance.getBlock(block.worldDimension(), block.x(), block.z()+1);
+        if (adjacent != null && adjacent.town() == town) return;
+        
+        throw new CommandException(Term.TownErrBlockTooCloseToAnotherTown);
+    }
+
     public void addBlock(TownBlock block) throws CommandException {
         addBlock(block, false);
     }
 
-    public void addBlock(TownBlock block, boolean bypassChecks)
-            throws CommandException {
+    public void addBlock(TownBlock block, boolean bypassChecks) throws CommandException {
         if (!bypassChecks) {
             canAddBlock(block, false, this);
         }
@@ -461,10 +460,8 @@ public class Town {
     public String serializeExtra() {
         return settings.serialize()
                 + ";"
-                + (spawnLocation == null ? "" : spawnDimension + "/"
-                        + spawnLocation.xCoord + "/" + spawnLocation.yCoord
-                        + "/" + spawnLocation.zCoord + "/" + spawnEye1 + "/"
-                        + spawnEye2);
+                + (spawnLocation == null ? "" : spawnDimension + "/" + spawnLocation.xCoord + "/" + spawnLocation.yCoord + "/"
+                        + spawnLocation.zCoord + "/" + spawnEye1 + "/" + spawnEye2);
     }
 
     public void deserializeExtra(String val) {
@@ -551,15 +548,13 @@ public class Town {
                 if (blocks_list.length() > 0) {
                     blocks_list.append(", ");
                 }
-                blocks_list.append(String.format("(%s,%s)", block.x(), block
-                        .z()));
+                blocks_list.append(String.format("(%s,%s)", block.x(), block.z()));
             }
         }
 
         String townColor = "§2";
         if (pl instanceof EntityPlayer) {
-            Resident target = MyTownDatasource.instance
-                    .getOrMakeResident((EntityPlayer) pl);
+            Resident target = MyTownDatasource.instance.getOrMakeResident((EntityPlayer) pl);
             if (target.town() != this) {
                 townColor = "§4";
             }
@@ -567,27 +562,22 @@ public class Town {
 
         pl.sendChatToPlayer(Term.TownStatusName.toString(townColor, t.name()));
 
-        pl.sendChatToPlayer(Term.TownStatusGeneral.toString(t.blocks().size(),
-                String.valueOf(t.totalBlocks()), t.nation() == null ? "none"
-                        : t.nation().name()));
+        pl.sendChatToPlayer(Term.TownStatusGeneral.toString(t.blocks().size(), String.valueOf(t.totalBlocks()), t.nation() == null ? "none"
+                : t.nation().name()));
         if (blocks_list.length() > 0) {
             pl.sendChatToPlayer(blocks_list.toString());
         }
 
         pl.sendChatToPlayer(Term.TownStatusMayor.toString(mayors.toString()));
-        pl.sendChatToPlayer(Term.TownStatusAssistants.toString(assistants
-                .toString()));
-        pl.sendChatToPlayer(Term.TownStatusResidents.toString(residents
-                .toString()));
+        pl.sendChatToPlayer(Term.TownStatusAssistants.toString(assistants.toString()));
+        pl.sendChatToPlayer(Term.TownStatusResidents.toString(residents.toString()));
     }
 
     public void notifyPlayerLoggedOn(Resident r) {
-        sendNotification(Level.INFO, Term.TownBroadcastLoggedIn.toString(r
-                .name()));
+        sendNotification(Level.INFO, Term.TownBroadcastLoggedIn.toString(r.name()));
     }
 
     public void notifyPlayerLoggedOff(Resident r) {
-        sendNotification(Level.INFO, Term.TownBroadcastLoggedOut.toString(r
-                .name()));
+        sendNotification(Level.INFO, Term.TownBroadcastLoggedOut.toString(r.name()));
     }
 }

--- a/src/ee/lutsu/alpha/mc/mytown/entities/Town.java
+++ b/src/ee/lutsu/alpha/mc/mytown/entities/Town.java
@@ -299,8 +299,8 @@ public class Town {
             throw new CommandException(Term.TownErrTownNameCannotBeEmpty);
         }
 
-        Town t = MyTownDatasource.instance.towns.get(name);
-        if (t != self) {
+        Town t = MyTownDatasource.instance.towns.get(name.toLowerCase());
+        if (t != null && t != self) {
             throw new CommandException(Term.TownErrTownNameAlreadyInUse);
         }
     }

--- a/src/ee/lutsu/alpha/mc/mytown/sql/MyTownDB.java
+++ b/src/ee/lutsu/alpha/mc/mytown/sql/MyTownDB.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import com.google.common.base.Joiner;
@@ -529,10 +530,10 @@ public abstract class MyTownDB extends Database {
 
     public abstract Town getTown(int id);
 
-    public List<Resident> loadResidents() {
+    public Map<String, Resident> loadResidents() {
         synchronized (lock) {
             ResultSet set = null;
-            List<Resident> residents = new ArrayList<Resident>();
+            Map<String, Resident> residents = new HashMap<String, Resident>();
             HashMap<Resident, String> friends = new HashMap<Resident, String>();
             try {
                 PreparedStatement statement = prepare("SELECT * FROM " + prefix
@@ -551,7 +552,7 @@ public abstract class MyTownDB extends Database {
                             .getString("LastLogin")), set.getString("Extra"),
                             set.getString("Homes"));
 
-                    residents.add(r);
+                    residents.put(r.name().toLowerCase(), r);
 
                     String f = set.getString("Friends");
                     if (f != null && f.length() > 0) {
@@ -574,7 +575,7 @@ public abstract class MyTownDB extends Database {
                 for (String sfid : ids) {
                     int fid = Integer.parseInt(sfid);
                     Resident friend = null;
-                    for (Resident r2 : residents) {
+                    for (Resident r2 : residents.values()) {
                         if (r2.id() == fid) {
                             friend = r2;
                             break;

--- a/src/ee/lutsu/alpha/mc/mytown/sql/MyTownDB.java
+++ b/src/ee/lutsu/alpha/mc/mytown/sql/MyTownDB.java
@@ -261,20 +261,21 @@ public abstract class MyTownDB extends Database {
         statement.executeUpdate();
     }
 
-    public List<Nation> loadNations() // has to happen after town load
+    public Map<String, Nation> loadNations() // has to happen after town load
     {
         synchronized (lock) {
             ResultSet set = null;
-            List<Nation> nations = new ArrayList<Nation>();
+            Map<String, Nation> nations = new HashMap<String, Nation>();
             try {
                 PreparedStatement statement = prepare("SELECT * FROM " + prefix
                         + "nations");
                 set = statement.executeQuery();
 
                 while (set.next()) {
-                    nations.add(Nation.sqlLoad(set.getInt("Id"), set
+                    Nation nation = Nation.sqlLoad(set.getInt("Id"), set
                             .getString("Name"), set.getInt("Capital"), set
-                            .getString("Towns"), set.getString("Extra")));
+                            .getString("Towns"), set.getString("Extra"));
+                    nations.put(nation.name().toLowerCase(), nation);
                 }
             } catch (Exception e) {
                 printException(e);
@@ -594,19 +595,20 @@ public abstract class MyTownDB extends Database {
         }
     }
 
-    public List<Town> loadTowns() {
+    public Map<String, Town> loadTowns() {
         synchronized (lock) {
             ResultSet set = null;
-            List<Town> towns = new ArrayList<Town>();
+            Map<String, Town> towns = new HashMap<String, Town>();
             try {
                 PreparedStatement statement = prepare("SELECT * FROM " + prefix
                         + "towns");
                 set = statement.executeQuery();
 
                 while (set.next()) {
-                    towns.add(loadFromSQL(set.getInt("Id"), set
+                    Town town = loadFromSQL(set.getInt("Id"), set
                             .getString("Name"), set.getInt("ExtraBlocks"), set
-                            .getString("Blocks"), set.getString("Extra")));
+                            .getString("Blocks"), set.getString("Extra"));
+                    towns.put(town.name().toLowerCase(), town);
                 }
             } catch (Exception e) {
                 printException(e);

--- a/src/mcmod.info
+++ b/src/mcmod.info
@@ -4,7 +4,7 @@
   "name": "MyTown",
   "description": "Adds the possibility to create towns in Minecraft server that protect the players
   and the player builds.",
-  "version": "1.5.1.6",
+  "version": "1.5.1.9e",
   "mcversion": "1.5.1",
   "url": "http://www.minecraftforum.net/topic/1650110-mytown-aperf-server-protection-and-performance-mods/",
   "updateUrl": "",

--- a/src/mcmod.info
+++ b/src/mcmod.info
@@ -4,7 +4,7 @@
   "name": "MyTown",
   "description": "Adds the possibility to create towns in Minecraft server that protect the players
   and the player builds.",
-  "version": "1.5.1.9e",
+  "version": "1.5.1.9f",
   "mcversion": "1.5.1",
   "url": "http://www.minecraftforum.net/topic/1650110-mytown-aperf-server-protection-and-performance-mods/",
   "updateUrl": "",


### PR DESCRIPTION
Maps instead of sets to hold data (much faster lookup by key, no speed difference when you have to check all objects anyway).
Would be best to make more use of sql for checking all objects - perhaps a new table to hold chunks, I'm pretty sure asking a database if there are any chunks in a radius of another is much faster than checking that manually in java.

Option for adjacent chunk claiming. If you have no chunks in a dimension, you can claim anywhere, otherwise the claim needs to touch (no corners) an existing claim - existing, so if an admin claims a remote chunk, you can have a sort of outpost. Needs to be enabled in config, there exists a bypass permission.
